### PR TITLE
Add boundary aspects

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -7,6 +7,7 @@ export type ReducersMapObjectContributor<TState = {}> = () => Redux.ReducersMapO
 export type ContributionPredicate = () => boolean
 export type LazyEntryPointFactory = () => Promise<EntryPoint>
 export type ShellsChangedCallback = (shellNames: string[]) => void
+export type ShellBoundaryAspect = React.FunctionComponent
 export interface LazyEntryPointDescriptor {
     readonly name: string
     readonly factory: LazyEntryPointFactory
@@ -79,6 +80,7 @@ export interface Shell extends Pick<AppHost, Exclude<keyof AppHost, 'getStore'>>
     contributeAPI<TAPI>(key: SlotKey<TAPI>, factory: () => TAPI): TAPI
     contributeState<TState>(contributor: ReducersMapObjectContributor<TState>): void
     contributeMainView(fromShell: Shell, contributor: ReactComponentContributor): void
+    contributeBoundaryAspect(component: ShellBoundaryAspect): void
     // readonly log: ShellLogger; //TODO: define logging abstraction
 }
 
@@ -86,6 +88,7 @@ export interface PrivateShell extends Shell {
     readonly entryPoint: EntryPoint
     setDependencyAPIs(APIs: AnySlotKey[]): void
     setLifecycleState(enableStore: boolean, enableAPIs: boolean): void
+    getBoundaryAspects(): ShellBoundaryAspect[]
 }
 
 export interface EntryPointsInfo {

--- a/src/appHost.ts
+++ b/src/appHost.ts
@@ -17,7 +17,8 @@ import {
     ScopedStore,
     Shell,
     ShellsChangedCallback,
-    SlotKey
+    SlotKey,
+    ShellBoundaryAspect
 } from './API'
 
 import _ from 'lodash'
@@ -498,6 +499,7 @@ function createAppHostImpl(): AppHost {
         let storeEnabled = false
         let APIsEnabled = false
         let dependencyAPIs: AnySlotKey[] = []
+        const boundaryAspects: ShellBoundaryAspect[] = []
 
         const isOwnContributedAPI = <TAPI>(key: SlotKey<TAPI>): boolean => getAPIContributor(key) === shell
 
@@ -604,6 +606,14 @@ function createAppHostImpl(): AppHost {
 
             contributeMainView(fromShell: Shell, contributor: ReactComponentContributor): void {
                 getSlot(mainViewSlotKey).contribute(fromShell, contributor)
+            },
+
+            contributeBoundaryAspect(component: ShellBoundaryAspect): void {
+                boundaryAspects.push(component)
+            },
+
+            getBoundaryAspects(): ShellBoundaryAspect[] {
+                return boundaryAspects
             }
         }
 

--- a/src/renderSlotComponents.tsx
+++ b/src/renderSlotComponents.tsx
@@ -1,9 +1,10 @@
 import _ from 'lodash'
 import React, { ReactNode } from 'react'
 import { connect } from 'react-redux'
-import { AppHost, ExtensionItem, ExtensionSlot, PrivateShell, ReactComponentContributor, Shell } from './API'
+import { AppHost, ExtensionItem, ExtensionSlot, PrivateShell, ReactComponentContributor, Shell, ShellBoundaryAspect } from './API'
 import { ErrorBoundary } from './errorBoundary'
 import { ShellContext } from './shellContext'
+import { contributeInstalledShellsState } from './installedShellsState'
 
 interface ShellRendererProps {
     shell: Shell
@@ -12,9 +13,20 @@ interface ShellRendererProps {
     name?: string
 }
 
+function renderWithAspects(shell: PrivateShell, component: ReactNode, aspectIndex: number): ReactNode {
+    const aspects = shell.getBoundaryAspects()
+
+    if (aspects && aspects.length > aspectIndex) {
+        const Aspect = aspects[aspectIndex]
+        return <Aspect>{renderWithAspects(shell, component, aspectIndex + 1)}</Aspect>
+    }
+
+    return component
+}
+
 export const ShellRenderer: React.FunctionComponent<ShellRendererProps> = ({ shell, component, key, name }) => (
     <ErrorBoundary key={key} shell={shell} componentName={name}>
-        <ShellContext.Provider value={shell}>{component}</ShellContext.Provider>
+        <ShellContext.Provider value={shell}>{renderWithAspects(shell as PrivateShell, component, 0)}</ShellContext.Provider>
     </ErrorBoundary>
 )
 

--- a/testKit/index.tsx
+++ b/testKit/index.tsx
@@ -2,7 +2,7 @@ import { mount, ReactWrapper } from 'enzyme'
 import _ from 'lodash'
 import React, { Component, ReactElement } from 'react'
 import { Provider } from 'react-redux'
-import { EntryPoint, PrivateShell } from '../src/API'
+import { EntryPoint, PrivateShell, ShellBoundaryAspect } from '../src/API'
 import { AnySlotKey, AppHost, AppMainView, createAppHost, EntryPointOrPackage, Shell, SlotKey } from '../src/index'
 import { ShellRenderer } from '../src/renderSlotComponents'
 
@@ -136,6 +136,7 @@ function createShell(host: AppHost): PrivateShell {
         ...host,
         declareSlot() {
             const slot: any = {}
+
             return slot
         },
         setLifecycleState: _.noop,
@@ -149,6 +150,10 @@ function createShell(host: AppHost): PrivateShell {
         contributeAPI<TAPI>(): TAPI {
             const API: any = {}
             return API
+        },
+        contributeBoundaryAspect(aspect: ShellBoundaryAspect): void {},
+        getBoundaryAspects(): ShellBoundaryAspect[] {
+            return []
         },
         contributeState: _.noop,
         contributeMainView: _.noop


### PR DESCRIPTION
Allow contributing more layers to component boundary, in addition to built-in `<ErrorBoundary>`. 

Example use case: every Shell-connected component must be wrapped in `<I18nextProvider>` in order to use a correct translations artifact (by package/bundle of the Shell).

The new API is:

```TypeScript
shell.contributeBoundaryAspect(() => <MyAspect />)
```

where

```TypeScript
const MyAspect: React.FunctionComponent<{}> = (props) => (
    <render-some-wrapper>
        {props.children}   
    </render-some-wrapper>
)
```

Contributed boundaries are per Shell. This allows every Entry Point to contribute different boundaries, or bind their boundaries to different data. In the future, we may add contribution of AppHost-wide boundaries. 

For contributing identical boundaries from multiple entry points, use entry point interceptors #13. Example: all entry points of a package contribute `<I18nextProvider>` bound to same translations artifact.

