### PR TITLE
#EDIX-78|Add debug utils

### DIFF
--- a/src/appHost.ts
+++ b/src/appHost.ts
@@ -97,15 +97,7 @@ function createAppHostImpl(): AppHost {
     }
 
     // TODO: Conditionally with parameter
-    window.repluggableAppDebug = {
-        host,
-        uniqueShellNames,
-        extensionSlots,
-        addedShells,
-        lazyShells,
-        readyAPIs,
-        shellInstallers
-    }
+    setupDebugInfo()
 
     declareSlot<ReactComponentContributor>(mainViewSlotKey)
     declareSlot<ReducersMapObjectContributor>(stateSlotKey)
@@ -610,5 +602,29 @@ function createAppHostImpl(): AppHost {
         }
 
         return shell
+    }
+
+    function setupDebugInfo() {
+        const utils = {
+            apis: () => {
+                return Array.from(readyAPIs).map((apiKey: AnySlotKey) => {
+                    return {
+                        key: apiKey,
+                        impl: () => getAPI(apiKey)
+                    }
+                })
+            }
+        }
+
+        window.repluggableAppDebug = {
+            host,
+            uniqueShellNames,
+            extensionSlots,
+            addedShells,
+            lazyShells,
+            readyAPIs,
+            shellInstallers,
+            utils
+        }
     }
 }

--- a/src/debug.d.ts
+++ b/src/debug.d.ts
@@ -16,4 +16,14 @@ export interface RepluggableAppDebugInfo {
     lazyShells: Map<string, LazyEntryPointFactory>
     readyAPIs: Set<AnySlotKey>
     shellInstallers: WeakMap<PrivateShell, string[]>
+    utils: RepluggableDebugUtils
+}
+
+export interface APIDebugInfo {
+    key: AnySlotKey
+    impl: () => any
+}
+
+export interface RepluggableDebugUtils {
+    apis: () => Array[APIDebugInfo]
 }


### PR DESCRIPTION
Add the ability to easily call APIs
```ts
// get list of all APIs
window.repluggableAppDebug.utils.apis()

// get API implementation
window.repluggableAppDebug.utils.apis()[2].impl()
```