### PR TITLE
Make comnectWithShell less opinionated about comparing function prop types

### DIFF
--- a/src/propsDeepEqual.tsx
+++ b/src/propsDeepEqual.tsx
@@ -1,6 +1,9 @@
 import _ from 'lodash'
+export interface ComparePropsOptions {
+    compareFuncProps: boolean
+}
 
-export const propsDeepEqual = (propsA: any, propsB: any) => {
+export const propsDeepEqual = ({ compareFuncProps }: ComparePropsOptions) => (propsA: any, propsB: any) => {
     const customizer: _.IsEqualCustomizer = (a, b, key, objectA) => {
         if (key === 'children' && objectA === propsA) {
             if (_.isFunction(a) && _.isFunction(b)) {
@@ -8,7 +11,7 @@ export const propsDeepEqual = (propsA: any, propsB: any) => {
             }
             return
         }
-        if (_.isFunction(a) && _.isFunction(b)) {
+        if (!compareFuncProps && _.isFunction(a) && _.isFunction(b)) {
             return true
         }
         return

--- a/src/renderSlotComponents.tsx
+++ b/src/renderSlotComponents.tsx
@@ -17,8 +17,8 @@ interface ShellRendererProps {
 const connectOptions: ReduxConnectOptions = {
     context: StoreContext,
     pure: true,
-    areStatePropsEqual: propsDeepEqual,
-    areOwnPropsEqual: propsDeepEqual
+    areStatePropsEqual: propsDeepEqual({ compareFuncProps: false }),
+    areOwnPropsEqual: propsDeepEqual({ compareFuncProps: false })
 }
 
 function renderWithAspects(shell: PrivateShell, component: ReactNode, aspectIndex: number): ReactNode {


### PR DESCRIPTION
### Problem: 
At the moment ``connectWithShell`` will implicitly compare only non function types among props of the connected component. By all means it's highly performant, but unexpected. Some components like ``ContextMenuButton`` are written in a such way that only a function could change through iterations. Moreover, if one enclose scoped arguments inside a function and this function prop will not be delivered down to the connected component, then we end up with outdated return results. 
 
### Suggestion:
Extend connectWithShell signature and give optional control over comparing props, just a flag 
```
export interface ComparePropsOptions {
    compareFuncProps: boolean
}
```
which is ``false`` by default and hence doesn't change the exiting flow or code