### PR TITLE
making hmr great again

### DIFF
--- a/src/hot.ts
+++ b/src/hot.ts
@@ -1,71 +1,25 @@
 import { EntryPoint } from './API'
 
-interface ModuleEntry {
-    oldShellNames: string[]
-    newEntryPoints?: EntryPoint[]
-}
-
-const moduleById: Record<string, ModuleEntry> = {}
-
-function getOrAddModuleEntry(moduleId: string, lastKnownEntryPoints: EntryPoint[]): ModuleEntry {
-    const existingEntry = moduleById[moduleId]
-    if (existingEntry) {
-        return existingEntry
-    }
-    const newEntry: ModuleEntry = {
-        oldShellNames: lastKnownEntryPoints.map(ep => ep.name),
-        newEntryPoints: undefined
-    }
-    moduleById[moduleId] = newEntry
-    return newEntry
-}
-
 export const hot = (sourceModule: any, entryPoints: EntryPoint[]): EntryPoint[] => {
     if (!sourceModule.hot) {
         return entryPoints // not a dev environment
     }
 
-    const urlParams = new URLSearchParams(window.location.search)
-    if (!urlParams.has('enableHMR')) {
-        return entryPoints
-    }
-
     const shortModuleId = sourceModule.id.split('/').pop()
-    console.debug(
-        `----- HMR[${shortModuleId}] > ENTER`,
-        entryPoints.map(ep => ep.name)
-    )
-    getOrAddModuleEntry(sourceModule.id, entryPoints).newEntryPoints = entryPoints
 
-    if (sourceModule.hot) {
-        sourceModule.hot.accept()
+    sourceModule.hot.accept()
+    sourceModule.hot.dispose(() => {
+        const oldShellNames = entryPoints.map(x => x.name)
+        console.debug(`----- HMR[${shortModuleId}] > REMOVING SHELLS >`, oldShellNames)
+        return window.repluggableAppDebug.host.removeShells(oldShellNames)
+    })
 
-        if (sourceModule.hot.addStatusHandler && sourceModule.hot.status() === 'idle') {
-            console.debug(`---- HMR[${shortModuleId}] > ADD STATUS HANDLER`)
-
-            sourceModule.hot.addStatusHandler(async (status: string) => {
-                console.debug(`-------- HMR[${shortModuleId}] > statusHandler(${status})`)
-                if (status === 'apply') {
-                    setTimeout(async () => {
-                        const entry = getOrAddModuleEntry(sourceModule.id, entryPoints)
-                        if (entry.newEntryPoints) {
-                            console.debug(`----- HMR[${shortModuleId}] > REMOVING SHELLS >`, entry.oldShellNames)
-
-                            await window.repluggableAppDebug.host.removeShells(entry.oldShellNames)
-
-                            console.debug(
-                                `----- HMR[${shortModuleId}] > ADDING SHELLS >`,
-                                entry.newEntryPoints.map(ep => ep.name)
-                            )
-
-                            window.repluggableAppDebug.host.addShells(entry.newEntryPoints)
-                            entry.oldShellNames = entry.newEntryPoints.map(ep => ep.name)
-                            entry.newEntryPoints = undefined
-                        }
-                    })
-                }
-            })
-        }
+    if (sourceModule.hot.status() === 'apply') {
+        console.debug(
+            `----- HMR[${shortModuleId}] > ADDING SHELLS >`,
+            entryPoints.map(x => x.name)
+        )
+        window.repluggableAppDebug.host.addShells(entryPoints)
     }
 
     return entryPoints

--- a/src/hot.ts
+++ b/src/hot.ts
@@ -1,23 +1,30 @@
 import { EntryPoint } from './API'
 
 export const hot = (sourceModule: any, entryPoints: EntryPoint[]): EntryPoint[] => {
-    if (sourceModule.hot) {
-        const shortModuleId = sourceModule.id.split('/').pop()
+    if (!sourceModule.hot) {
+        return entryPoints
+    }
 
-        sourceModule.hot.accept()
-        sourceModule.hot.dispose(() => {
-            const oldShellNames = entryPoints.map(x => x.name)
-            console.debug(`----- HMR[${shortModuleId}] > REMOVING SHELLS >`, oldShellNames)
-            return window.repluggableAppDebug.host.removeShells(oldShellNames)
-        })
+    const urlParams = new URLSearchParams(window.location.search)
+    if (!urlParams.has('enableHMR')) {
+        return entryPoints
+    }
 
-        if (sourceModule.hot.status() === 'apply') {
-            console.debug(
-                `----- HMR[${shortModuleId}] > ADDING SHELLS >`,
-                entryPoints.map(x => x.name)
-            )
-            window.repluggableAppDebug.host.addShells(entryPoints)
-        }
+    const shortModuleId = sourceModule.id.split('/').pop()
+
+    sourceModule.hot.accept()
+    sourceModule.hot.dispose(() => {
+        const oldShellNames = entryPoints.map(x => x.name)
+        console.debug(`----- HMR[${shortModuleId}] > REMOVING SHELLS >`, oldShellNames)
+        return window.repluggableAppDebug.host.removeShells(oldShellNames)
+    })
+
+    if (sourceModule.hot.status() === 'apply') {
+        console.debug(
+            `----- HMR[${shortModuleId}] > ADDING SHELLS >`,
+            entryPoints.map(x => x.name)
+        )
+        window.repluggableAppDebug.host.addShells(entryPoints)
     }
 
     return entryPoints

--- a/src/hot.ts
+++ b/src/hot.ts
@@ -1,25 +1,23 @@
 import { EntryPoint } from './API'
 
 export const hot = (sourceModule: any, entryPoints: EntryPoint[]): EntryPoint[] => {
-    if (!sourceModule.hot) {
-        return entryPoints // not a dev environment
-    }
+    if (sourceModule.hot) {
+        const shortModuleId = sourceModule.id.split('/').pop()
 
-    const shortModuleId = sourceModule.id.split('/').pop()
+        sourceModule.hot.accept()
+        sourceModule.hot.dispose(() => {
+            const oldShellNames = entryPoints.map(x => x.name)
+            console.debug(`----- HMR[${shortModuleId}] > REMOVING SHELLS >`, oldShellNames)
+            return window.repluggableAppDebug.host.removeShells(oldShellNames)
+        })
 
-    sourceModule.hot.accept()
-    sourceModule.hot.dispose(() => {
-        const oldShellNames = entryPoints.map(x => x.name)
-        console.debug(`----- HMR[${shortModuleId}] > REMOVING SHELLS >`, oldShellNames)
-        return window.repluggableAppDebug.host.removeShells(oldShellNames)
-    })
-
-    if (sourceModule.hot.status() === 'apply') {
-        console.debug(
-            `----- HMR[${shortModuleId}] > ADDING SHELLS >`,
-            entryPoints.map(x => x.name)
-        )
-        window.repluggableAppDebug.host.addShells(entryPoints)
+        if (sourceModule.hot.status() === 'apply') {
+            console.debug(
+                `----- HMR[${shortModuleId}] > ADDING SHELLS >`,
+                entryPoints.map(x => x.name)
+            )
+            window.repluggableAppDebug.host.addShells(entryPoints)
+        }
     }
 
     return entryPoints


### PR DESCRIPTION
When loading each package:
* Accept all package changes
* Subscribe to onDispose --> when HMR unloads this package, we remove the relevant shells from repluggable
* If we loaded this module during apply phase, this means we are during HMR for it, so add the shells to repluggable