### PR TITLE
Fix create-new-project section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ $ npm install repluggable
 ## Create a new Repluggable project
 Run the following commands:
 ```
-create-react-app your-app-name --template typescript
+npx create-react-app your-app-name --template typescript
 cd your-app-name
-yarn add repluggable
+yarn add react@^16.14.0 react-dom@^16.14.0 @types/react@^16.14.0 @types/react-dom@^16.9.0 repluggable
 rm src/App*
 rm src/logo*
 \cp -R node_modules/repluggable/examples/helloWorld/src/ ./src


### PR DESCRIPTION
Readme of creating new project is not up to date
* Global create-react-app not supported as global command -> changed to run with `npx`
* Conflicting react versions -> Forced React@16.14 until React@17 is tested


Fixing https://github.com/wix/repluggable/issues/147