### PR TITLE
Add renderOutsideProvider option to connectWithShell

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -470,6 +470,7 @@ export interface PrivateShell extends Shell {
     setLifecycleState(enableStore: boolean, enableAPIs: boolean, initCompleted: boolean): void
     getBoundaryAspects(): ShellBoundaryAspect[]
     getHostOptions(): AppHostOptions
+    wrapWithShellRenderer(component: JSX.Element): JSX.Element
 }
 
 export interface EntryPointsInfo {

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { AnyAction, Store } from 'redux'
 import {
     AnyEntryPoint,
@@ -47,9 +48,12 @@ import { ConsoleHostLogger, createShellLogger } from './loggers'
 import { monitorAPI } from './monitorAPI'
 import { Graph, Tarjan } from './tarjanGraph'
 import { setupDebugInfo } from './repluggableAppDebug'
+import { ShellRenderer } from '.'
 
-const isMultiArray = <T>(v: T[] | T[][]): v is T[][] => _.every(v, _.isArray)
-const castMultiArray = <T>(v: T[] | T[][]): T[][] => {
+function isMultiArray<T>(v: T[] | T[][]): v is T[][] {
+    return _.every(v, _.isArray)
+}
+function castMultiArray<T>(v: T[] | T[][]): T[][] {
     return isMultiArray(v) ? v : [v]
 }
 
@@ -765,7 +769,9 @@ miss: ${memoizedWithMissHit.miss}
         let nextObservableId = 1
         const boundaryAspects: ShellBoundaryAspect[] = []
 
-        const isOwnContributedAPI = <TAPI>(key: SlotKey<TAPI>): boolean => getAPIContributor(key) === shell
+        function isOwnContributedAPI<TAPI>(key: SlotKey<TAPI>): boolean {
+            return getAPIContributor(key) === shell
+        }
 
         const shell: PrivateShell = {
             name: entryPoint.name,
@@ -975,7 +981,11 @@ miss: ${memoizedWithMissHit.miss}
 
             getHostOptions: () => host.options,
 
-            log: createShellLogger(host, entryPoint)
+            log: createShellLogger(host, entryPoint),
+
+            wrapWithShellRenderer(component): JSX.Element {
+                return <ShellRenderer shell={shell} component={component} host={host} />
+            }
         }
 
         return shell

--- a/src/renderSlotComponents.tsx
+++ b/src/renderSlotComponents.tsx
@@ -9,7 +9,7 @@ import { StoreContext } from './storeContext'
 
 interface ShellRendererProps {
     shell: Shell
-    component: React.ReactNode
+    component: JSX.Element
     name?: string
     host?: AppHost
 }

--- a/test/connectWithShell.spec.tsx
+++ b/test/connectWithShell.spec.tsx
@@ -12,7 +12,7 @@ import {
     connectWithShellAndObserve,
     withThrowOnError
 } from '../testKit'
-import { ReactWrapper } from 'enzyme'
+import { mount, ReactWrapper } from 'enzyme'
 import { AnyAction } from 'redux'
 
 interface MockPackageState {
@@ -54,6 +54,21 @@ describe('connectWithShell', () => {
         const { parentWrapper: comp } = renderInShellContext(<ConnectedComp />)
 
         expect(comp && comp.text()).toBe(mockPackage.name)
+    })
+
+    it('should have shell context outside of main view with renderOutsideProvider option', () => {
+        const { shell } = createMocks(mockPackage)
+
+        const PureComp = ({ shellName }: { shellName: string }) => <div className={'my-wrapper'}>{shellName}</div>
+        const mapStateToProps = (s: Shell) => ({ shellName: s.name })
+
+        const ConnectedComp = connectWithShell(mapStateToProps, undefined, shell, { renderOutsideProvider: true })(PureComp)
+
+        const reactWrapper = mount(<ConnectedComp />)
+        const myWrapperDiv = reactWrapper.find('.my-wrapper')
+
+        expect(myWrapperDiv).toBeDefined()
+        expect(myWrapperDiv && myWrapperDiv.text()).toBe(mockPackage.name)
     })
 
     it('should pass exact shell to mapDispatchToProps', () => {

--- a/test/connectWithShell.spec.tsx
+++ b/test/connectWithShell.spec.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import React, { FunctionComponent, ReactElement } from 'react'
+import React, { FunctionComponent, ReactElement, useEffect } from 'react'
 
 import { AppHost, EntryPoint, Shell, SlotKey, ObservableState, AnySlotKey } from '../src/API'
 import {
@@ -497,9 +497,13 @@ describe('connectWithShell-useCases', () => {
     }
 
     const renderSpy = jest.fn()
+    const mountSpy = jest.fn()
     const mapStateToPropsSpy = jest.fn()
 
     const PureComp: FunctionComponent<CompProps> = ({ valueOne, valueTwo, valueThree }) => {
+        useEffect(() => {
+            mountSpy()
+        }, [])
         renderSpy()
         return (
             <div>
@@ -561,6 +565,23 @@ describe('connectWithShell-useCases', () => {
 
         expect(receivedSelectors.length).toBe(1)
         expect(receivedSelectors[0].getValueThree()).toBe('updated_by_test')
+    })
+
+    it('should not mount connected component on props update', () => {
+        const { host, shell, renderInShellContext } = createMocks(entryPointOne, [entryPointTwo])
+        const ConnectedComp = connectWithShell(mapStateToProps, undefined, shell)(PureComp)
+        const { root } = renderInShellContext(<ConnectedComp />)
+        if (!root) {
+            throw new Error('Connected component failed to render')
+        }
+
+        expect(renderSpy).toHaveBeenCalledTimes(1)
+        expect(mountSpy).toHaveBeenCalledTimes(1)
+
+        handleAction({ type: 'SET_ONE', value: 'update1' }, root, host)
+
+        expect(renderSpy).toHaveBeenCalledTimes(2)
+        expect(mountSpy).toHaveBeenCalledTimes(1)
     })
 
     it('should update component on change in regular state', () => {

--- a/testKit/index.tsx
+++ b/testKit/index.tsx
@@ -196,7 +196,8 @@ function createShell(host: AppHost): PrivateShell {
         memoize: _.identity,
         clearCache: _.noop,
         getHostOptions: () => host.options,
-        log: createShellLogger(host, entryPoint)
+        log: createShellLogger(host, entryPoint),
+        wrapWithShellRenderer: component => component
     }
 }
 


### PR DESCRIPTION
Add `renderOutsideProvider` option to `connectWithShell` function, that wraps the the connected component with host and shell contexts .
This should allow valid connection of components to the store, even when they're not rendered inside the main view.