### PR TITLE
Memory leak fix

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -467,6 +467,7 @@ export interface Shell extends Pick<AppHost, Exclude<keyof AppHost, 'getStore' |
 export interface PrivateShell extends Shell {
     readonly entryPoint: EntryPoint
     setDependencyAPIs(APIs: AnySlotKey[]): void
+    removeFromMemoizeForState(func: AnyFunction): void;
     setLifecycleState(enableStore: boolean, enableAPIs: boolean, initCompleted: boolean): void
     getBoundaryAspects(): ShellBoundaryAspect[]
     getHostOptions(): AppHostOptions

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -981,6 +981,7 @@ miss: ${memoizedWithMissHit.miss}
             },
             removeFromMemoizeForState(func) {
                 const memoizedFn = functionToMemFunction.get(func)
+                functionToMemFunction.delete(func)
 
                 const indexToDelete = memoizedFunctionData.findIndex(it => it === memoizedFn)
 

--- a/src/connectWithShell.tsx
+++ b/src/connectWithShell.tsx
@@ -92,6 +92,12 @@ function wrapWithShellContext<S, OP, SP, DP>(
             )(component as React.ComponentType<any>) as React.ComponentType<any> // TODO: Fix 'as any'
         }
 
+        componentWillUnmount() {
+            if (options.shouldComponentUpdate) {
+                ((this.props.shell as unknown) as PrivateShell).removeFromMemoizeForState(options.shouldComponentUpdate)
+            }
+        }
+
         public render() {
             const Component = this.connectedComponent
             const props = _.omit(this.props, 'shell') as OP

--- a/testKit/index.tsx
+++ b/testKit/index.tsx
@@ -193,6 +193,7 @@ function createShell(host: AppHost): PrivateShell {
         contributeMainView: _.noop,
         flushMemoizedForState: _.noop,
         memoizeForState: _.identity,
+        removeFromMemoizeForState: _.identity,
         memoize: _.identity,
         clearCache: _.noop,
         getHostOptions: () => host.options,


### PR DESCRIPTION
Today anytime when memoizeForState is used, it creates a memoized function that is live forever in memory.

In connectWithShell, it is using for memoization of shouldComponentUpdate which creates new memoized function on each component render. It leads detached node list issue(in React 16.X).

Removing memoized function(note: it's not cache cleaning) on component unmount fix memory leak issue.

TODO:

- [ ] Remove memoized function when shell is destroyed: if package will be removed dynamically, repluggable have to remove all memoized function that was added through removed shell