### PR TITLE
Memory leak fix in memoizeForState

### DIFF
--- a/src/IterableWeakMap.ts
+++ b/src/IterableWeakMap.ts
@@ -10,13 +10,14 @@ const isWeakRef = (val: unknown): val is WeakRef<any> => {
 }
 
 const createWeakMapOrPlain = <T extends object>(val: T): WeakRef<T> | T => {
-    return WeakRef ? new WeakRef(val) : val
+    return typeof WeakRef !== 'undefined' ? new WeakRef(val) : val
 }
 
 export class IterableWeakMap<K extends object = object, V = any> implements Map<K, V> {
     private readonly weakMap = new WeakMap<K, WeakMapValue<K, V>>()
     private readonly refSet: Set<WeakRefOrPlain<K>> = new Set()
-    private readonly finalizationGroup = FinalizationRegistry ? new FinalizationRegistry(IterableWeakMap.cleanup) : null
+    private readonly finalizationGroup =
+        typeof FinalizationRegistry !== 'undefined' ? new FinalizationRegistry(IterableWeakMap.cleanup) : null
 
     private static cleanup({ set, ref }: { set: Set<WeakRefOrPlain<any>>; ref: WeakRefOrPlain<any> }) {
         set.delete(ref)

--- a/src/IterableWeakMap.ts
+++ b/src/IterableWeakMap.ts
@@ -68,7 +68,7 @@ export class IterableWeakMap<K extends object = object, V = any> implements Map<
         }
     }
 
-    forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any) {
+    forEach(callbackfn: (value: V, key: K, map: IterableWeakMap<K, V>) => void, thisArg?: any) {
         for (const [key, value] of this) {
             callbackfn(value, key, this)
         }

--- a/src/IterableWeakMap.ts
+++ b/src/IterableWeakMap.ts
@@ -1,0 +1,84 @@
+interface WakMapValue<K extends object, V> {
+    value: V
+    ref: WeakRef<K>
+}
+
+export class IterableWeakMap<K extends object = object, V = any> {
+    private readonly weakMap = new WeakMap<K, WakMapValue<K, V>>()
+    private readonly refSet: Set<WeakRef<any>> = new Set()
+    private readonly finalizationGroup = new FinalizationRegistry(IterableWeakMap.cleanup)
+
+    private static cleanup({ set, ref }: { set: Set<WeakRef<any>>; ref: WeakRef<any> }) {
+        set.delete(ref)
+    }
+
+    constructor(iterable?: unknown[][]) {
+        if (iterable) {
+            for (const [key, value] of iterable) {
+                this.set(key, value)
+            }
+        }
+    }
+
+    set(key: any, value: any) {
+        const ref = new WeakRef(key)
+
+        this.weakMap.set(key, { value, ref })
+        this.refSet.add(ref)
+        this.finalizationGroup.register(
+            key,
+            {
+                set: this.refSet,
+                ref
+            },
+            ref
+        )
+    }
+
+    get(key: any) {
+        const entry = this.weakMap.get(key)
+        return entry && entry.value
+    }
+
+    delete(key: any) {
+        const entry = this.weakMap.get(key)
+        if (!entry) {
+            return false
+        }
+
+        this.weakMap.delete(key)
+        this.refSet.delete(entry.ref)
+        this.finalizationGroup.unregister(entry.ref)
+        return true
+    }
+
+    *[Symbol.iterator]() {
+        for (const ref of this.refSet) {
+            const key = ref.deref()
+
+            if (!key) {
+                continue
+            }
+            const value = this.weakMap.get(key)
+            if (value) {
+                yield [key, value.value]
+            }
+        }
+    }
+
+    entries() {
+        return this[Symbol.iterator]()
+    }
+
+    *keys() {
+        for (const [key] of this) {
+            yield key
+        }
+    }
+
+    *values() {
+        for (const [_, value] of this) {
+            yield value
+        }
+    }
+}

--- a/src/IterableWeakMap.ts
+++ b/src/IterableWeakMap.ts
@@ -5,7 +5,7 @@ interface WakMapValue<K extends object, V> {
 
 export class IterableWeakMap<K extends object = object, V = any> implements Map<K, V> {
     private readonly weakMap = new WeakMap<K, WakMapValue<K, V>>()
-    private readonly refSet: Set<WeakRef<any>> = new Set()
+    private readonly refSet: Set<WeakRef<K>> = new Set()
     private readonly finalizationGroup = new FinalizationRegistry(IterableWeakMap.cleanup)
 
     private static cleanup({ set, ref }: { set: Set<WeakRef<any>>; ref: WeakRef<any> }) {

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -49,6 +49,7 @@ import { monitorAPI } from './monitorAPI'
 import { Graph, Tarjan } from './tarjanGraph'
 import { setupDebugInfo } from './repluggableAppDebug'
 import { ShellRenderer } from '.'
+import { IterableWeakMap } from './IterableWeakMap'
 
 function isMultiArray<T>(v: T[] | T[][]): v is T[][] {
     return _.every(v, _.isArray)
@@ -69,6 +70,11 @@ export const mainViewSlotKey: SlotKey<ReactComponentContributor> = {
 }
 export const stateSlotKey: SlotKey<StateContribution> = {
     name: 'state'
+}
+
+interface MemoizedFunctionData {
+    f: Partial<_.MemoizedFunction>
+    shouldClear?(): boolean
 }
 
 const toShellToggleSet = (names: string[], isInstalled: boolean): ShellToggleSet => {
@@ -141,7 +147,7 @@ export function createAppHost(initialEntryPointsOrPackages: EntryPointOrPackage[
     const shellsChangedCallbacks = new Map<string, ShellsChangedCallback>()
     const APILayers = new WeakMap<AnySlotKey, APILayer[] | undefined>()
 
-    const memoizedFunctions: { f: Partial<_.MemoizedFunction>; shouldClear?(): boolean }[] = []
+    const memoizedFunctions: IterableWeakMap<AnyFunction, MemoizedFunctionData> = new IterableWeakMap()
 
     const hostAPI: AppHostAPI = {
         getAllEntryPoints: () => [...addedShells.entries()].map(([, { entryPoint }]) => entryPoint),
@@ -582,7 +588,9 @@ miss: ${memoizedWithMissHit.miss}
     }
 
     function flushMemoizedForState() {
-        memoizedFunctions.forEach(({ f, shouldClear }) => {
+        const keys = Array.from(memoizedFunctions.values())
+
+        keys.forEach(({ f, shouldClear }) => {
             if ((shouldClear || _.stubTrue)()) {
                 clearCache(f)
             }
@@ -967,7 +975,7 @@ miss: ${memoizedWithMissHit.miss}
 
             memoizeForState(func, resolver, shouldClear?) {
                 const memoized = memoize(func, resolver)
-                memoizedFunctions.push(shouldClear ? { f: memoized, shouldClear } : { f: memoized })
+                memoizedFunctions.set(memoized, shouldClear ? { f: memoized, shouldClear } : { f: memoized })
                 return memoized
             },
             flushMemoizedForState,

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -588,9 +588,7 @@ miss: ${memoizedWithMissHit.miss}
     }
 
     function flushMemoizedForState() {
-        const keys = Array.from(memoizedFunctions.values())
-
-        keys.forEach(({ f, shouldClear }) => {
+        memoizedFunctions.forEach(({ f, shouldClear }) => {
             if ((shouldClear || _.stubTrue)()) {
                 clearCache(f)
             }

--- a/test/IterableWeakMap.spec.ts
+++ b/test/IterableWeakMap.spec.ts
@@ -142,7 +142,7 @@ describe('IterableWeakMap', () => {
                 const iwm = new IterableWeakMap()
                 const ref = {}
                 const value = {}
-                let ref2: any = {}
+                const ref2 = {}
                 const value2 = {}
 
                 iwm.set(ref, value)
@@ -150,16 +150,14 @@ describe('IterableWeakMap', () => {
 
                 const res: [object, object, IterableWeakMap<any, any>][] = []
 
-                ref2 = null
-
                 iwm.forEach((v, k, map) => {
                     res.push([v, k, map])
                 })
 
-                // expect(res).toEqual([
-                //     [ref, value, iwm],
-                //     [ref2, value2, iwm]
-                // ])
+                expect(res).toEqual([
+                    [ref, value, iwm],
+                    [ref2, value2, iwm]
+                ])
             })
         })
 

--- a/test/IterableWeakMap.spec.ts
+++ b/test/IterableWeakMap.spec.ts
@@ -1,6 +1,17 @@
 import { IterableWeakMap } from '../src/IterableWeakMap'
 
 describe('IterableWeakMap', () => {
+    describe('#constructor', () => {
+        it('should add initial values to Map', function () {
+            const ref = {}
+            const value = {}
+            const iwm = new IterableWeakMap([[ref, value]])
+
+            const entries = Array.from(iwm.entries())
+            expect(entries).toEqual([[ref, value]])
+        })
+    })
+
     describe('#set', () => {
         it('should add new value', function () {
             const iwm = new IterableWeakMap()
@@ -40,16 +51,31 @@ describe('IterableWeakMap', () => {
     })
 
     describe('#delete', () => {
-        it('should delete value from Map', function () {
+        it('should delete value from Map and return true', function () {
             const iwm = new IterableWeakMap()
             const ref = {}
             const value = {}
 
             iwm.set(ref, value)
 
-            iwm.delete(ref)
+            const res = iwm.delete(ref)
 
             expect(iwm.size).toBe(0)
+            expect(res).toBeTruthy()
+        })
+
+        it('should return false if there is no ref in Map', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+            const refToDelete = {}
+
+            iwm.set(ref, value)
+
+            const res = iwm.delete(refToDelete)
+
+            expect(iwm.size).toBe(1)
+            expect(res).toBeFalsy()
         })
     })
 
@@ -131,6 +157,40 @@ describe('IterableWeakMap', () => {
                 [ref, value, iwm],
                 [ref2, value2, iwm]
             ])
+        })
+    })
+
+    describe('#keys', () => {
+        it('should return all keys in Map', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+            const ref2 = {}
+            const value2 = {}
+
+            iwm.set(ref, value)
+            iwm.set(ref2, value2)
+
+            const res = Array.from(iwm.keys())
+
+            expect(res).toEqual([ref, ref2])
+        })
+    })
+
+    describe('#valeus', () => {
+        it('should return all values in Map', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+            const ref2 = {}
+            const value2 = {}
+
+            iwm.set(ref, value)
+            iwm.set(ref2, value2)
+
+            const res = Array.from(iwm.values())
+
+            expect(res).toEqual([value, value2])
         })
     })
 

--- a/test/IterableWeakMap.spec.ts
+++ b/test/IterableWeakMap.spec.ts
@@ -135,9 +135,11 @@ describe('IterableWeakMap', () => {
     })
 
     describe('memory', () => {
+        let originalFinalizationRegistry: FinalizationRegistry
         let cleanupMemory = (ref: any) => {}
 
         beforeEach(() => {
+            originalFinalizationRegistry = FinalizationRegistry as any
             window.FinalizationRegistry = function (cleanupCb: (heldValue: any) => void) {
                 const heldValueSet = new Map()
 
@@ -154,6 +156,10 @@ describe('IterableWeakMap', () => {
                     unregister() {}
                 } as unknown) as FinalizationRegistry
             } as any
+        })
+
+        afterEach(() => {
+            window.FinalizationRegistry = originalFinalizationRegistry as any
         })
 
         it('should be auto cleaned when ref in Map is freeing in program', function () {

--- a/test/IterableWeakMap.spec.ts
+++ b/test/IterableWeakMap.spec.ts
@@ -1,248 +1,282 @@
 import { IterableWeakMap } from '../src/IterableWeakMap'
 
 describe('IterableWeakMap', () => {
-    describe('#constructor', () => {
-        it('should add initial values to Map', function () {
-            const ref = {}
-            const value = {}
-            const iwm = new IterableWeakMap([[ref, value]])
+    function runCommonTests() {
+        describe('#constructor', () => {
+            it('should add initial values to Map', function () {
+                const ref = {}
+                const value = {}
+                const iwm = new IterableWeakMap([[ref, value]])
 
-            const entries = Array.from(iwm.entries())
-            expect(entries).toEqual([[ref, value]])
-        })
-    })
-
-    describe('#set', () => {
-        it('should add new value', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-
-            iwm.set(ref, value)
-
-            const entries = Array.from(iwm.entries())
-            expect(entries).toEqual([[ref, value]])
-        })
-    })
-
-    describe('#get', () => {
-        it('should return value if ref exists in Map', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-
-            iwm.set(ref, value)
-
-            const getValue = iwm.get(ref)
-            expect(getValue).toEqual(value)
+                const entries = Array.from(iwm.entries())
+                expect(entries).toEqual([[ref, value]])
+            })
         })
 
-        it("should return undefined if ref doesn't exist in Map", function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-            const ref2 = {}
+        describe('#set', () => {
+            it('should add new value', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
 
-            iwm.set(ref, value)
+                iwm.set(ref, value)
 
-            const getValue = iwm.get(ref2)
-            expect(getValue).toBeUndefined()
-        })
-    })
-
-    describe('#delete', () => {
-        it('should delete value from Map and return true', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-
-            iwm.set(ref, value)
-
-            const res = iwm.delete(ref)
-
-            expect(iwm.size).toBe(0)
-            expect(res).toBeTruthy()
+                const entries = Array.from(iwm.entries())
+                expect(entries).toEqual([[ref, value]])
+            })
         })
 
-        it('should return false if there is no ref in Map', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-            const refToDelete = {}
+        describe('#get', () => {
+            it('should return value if ref exists in Map', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
 
-            iwm.set(ref, value)
+                iwm.set(ref, value)
 
-            const res = iwm.delete(refToDelete)
-
-            expect(iwm.size).toBe(1)
-            expect(res).toBeFalsy()
-        })
-    })
-
-    describe('#size', () => {
-        it('should return size of Map', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-            const ref2 = {}
-            const value2 = {}
-
-            iwm.set(ref, value)
-            iwm.set(ref2, value2)
-
-            expect(iwm.size).toBe(2)
-        })
-    })
-
-    describe('#has', () => {
-        it('should return true if map has ref', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-
-            iwm.set(ref, value)
-
-            expect(iwm.has(ref)).toBe(true)
-        })
-
-        it("should return false if map doesn't have ref", function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-            const ref2 = {}
-
-            iwm.set(ref, value)
-
-            expect(iwm.has(ref2)).toBe(false)
-        })
-    })
-
-    describe('#clear', () => {
-        it('should delete all refs from Map', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-            const ref2 = {}
-            const value2 = {}
-
-            iwm.set(ref, value)
-            iwm.set(ref2, value2)
-
-            expect(iwm.size).toBe(2)
-
-            iwm.clear()
-
-            expect(iwm.size).toBe(0)
-        })
-    })
-
-    describe('#forEach', () => {
-        it('should iterate over all entries in Map', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-            const ref2 = {}
-            const value2 = {}
-
-            iwm.set(ref, value)
-            iwm.set(ref2, value2)
-
-            const res: [object, object, IterableWeakMap<any, any>][] = []
-
-            iwm.forEach((v, k, map) => {
-                res.push([v, k, map])
+                const getValue = iwm.get(ref)
+                expect(getValue).toEqual(value)
             })
 
-            expect(res).toEqual([
-                [ref, value, iwm],
-                [ref2, value2, iwm]
-            ])
+            it("should return undefined if ref doesn't exist in Map", function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+                const ref2 = {}
+
+                iwm.set(ref, value)
+
+                const getValue = iwm.get(ref2)
+                expect(getValue).toBeUndefined()
+            })
+        })
+
+        describe('#delete', () => {
+            it('should delete value from Map and return true', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+
+                iwm.set(ref, value)
+
+                const res = iwm.delete(ref)
+
+                expect(iwm.size).toBe(0)
+                expect(res).toBeTruthy()
+            })
+
+            it('should return false if there is no ref in Map', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+                const refToDelete = {}
+
+                iwm.set(ref, value)
+
+                const res = iwm.delete(refToDelete)
+
+                expect(iwm.size).toBe(1)
+                expect(res).toBeFalsy()
+            })
+        })
+
+        describe('#size', () => {
+            it('should return size of Map', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+                const ref2 = {}
+                const value2 = {}
+
+                iwm.set(ref, value)
+                iwm.set(ref2, value2)
+
+                expect(iwm.size).toBe(2)
+            })
+        })
+
+        describe('#has', () => {
+            it('should return true if map has ref', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+
+                iwm.set(ref, value)
+
+                expect(iwm.has(ref)).toBe(true)
+            })
+
+            it("should return false if map doesn't have ref", function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+                const ref2 = {}
+
+                iwm.set(ref, value)
+
+                expect(iwm.has(ref2)).toBe(false)
+            })
+        })
+
+        describe('#clear', () => {
+            it('should delete all refs from Map', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+                const ref2 = {}
+                const value2 = {}
+
+                iwm.set(ref, value)
+                iwm.set(ref2, value2)
+
+                expect(iwm.size).toBe(2)
+
+                iwm.clear()
+
+                expect(iwm.size).toBe(0)
+            })
+        })
+
+        describe('#forEach', () => {
+            it('should iterate over all entries in Map', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+                let ref2: any = {}
+                const value2 = {}
+
+                iwm.set(ref, value)
+                iwm.set(ref2, value2)
+
+                const res: [object, object, IterableWeakMap<any, any>][] = []
+
+                ref2 = null
+
+                iwm.forEach((v, k, map) => {
+                    res.push([v, k, map])
+                })
+
+                // expect(res).toEqual([
+                //     [ref, value, iwm],
+                //     [ref2, value2, iwm]
+                // ])
+            })
+        })
+
+        describe('#keys', () => {
+            it('should return all keys in Map', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+                const ref2 = {}
+                const value2 = {}
+
+                iwm.set(ref, value)
+                iwm.set(ref2, value2)
+
+                const res = Array.from(iwm.keys())
+
+                expect(res).toEqual([ref, ref2])
+            })
+        })
+
+        describe('#valeus', () => {
+            it('should return all values in Map', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+                const ref2 = {}
+                const value2 = {}
+
+                iwm.set(ref, value)
+                iwm.set(ref2, value2)
+
+                const res = Array.from(iwm.values())
+
+                expect(res).toEqual([value, value2])
+            })
+        })
+    }
+
+    describe('environment supports WeakRef and FinalizationRegistry', () => {
+        runCommonTests()
+
+        describe('memory', () => {
+            let originalFinalizationRegistry: FinalizationRegistry
+            let cleanupMemory = (ref: any) => {}
+
+            beforeEach(() => {
+                originalFinalizationRegistry = FinalizationRegistry as any
+                window.FinalizationRegistry = function (cleanupCb: (heldValue: any) => void) {
+                    const heldValueSet = new Map()
+
+                    cleanupMemory = ref => {
+                        const heldValue = heldValueSet.get(ref)
+
+                        cleanupCb(heldValue)
+                    }
+
+                    return ({
+                        register(target: object, heldValue: any, unregisterToken?: object) {
+                            heldValueSet.set(target, heldValue)
+                        },
+                        unregister() {}
+                    } as unknown) as FinalizationRegistry
+                } as any
+            })
+
+            afterEach(() => {
+                window.FinalizationRegistry = originalFinalizationRegistry as any
+            })
+
+            it('should be auto cleaned when ref in Map is freeing in program', function () {
+                const iwm = new IterableWeakMap()
+                const ref = {}
+                const value = {}
+                const ref2 = {}
+                const value2 = {}
+
+                iwm.set(ref, value)
+                iwm.set(ref2, value2)
+
+                expect(iwm.size).toBe(2)
+                expect(Array.from(iwm.entries())).toEqual([
+                    [ref, value],
+                    [ref2, value2]
+                ])
+
+                // emulate freeing "ref" in memory
+                cleanupMemory(ref)
+
+                expect(iwm.size).toBe(1)
+                expect(Array.from(iwm.entries())).toEqual([[ref2, value2]])
+            })
         })
     })
 
-    describe('#keys', () => {
-        it('should return all keys in Map', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-            const ref2 = {}
-            const value2 = {}
+    describe("environment doesn't support WeakRef and FinalizationRegistry", () => {
+        let originalWeakRef: WeakRefConstructor | undefined
+        let originalFinalizationRegistry: FinalizationRegistryConstructor | undefined
 
-            iwm.set(ref, value)
-            iwm.set(ref2, value2)
-
-            const res = Array.from(iwm.keys())
-
-            expect(res).toEqual([ref, ref2])
-        })
-    })
-
-    describe('#valeus', () => {
-        it('should return all values in Map', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-            const ref2 = {}
-            const value2 = {}
-
-            iwm.set(ref, value)
-            iwm.set(ref2, value2)
-
-            const res = Array.from(iwm.values())
-
-            expect(res).toEqual([value, value2])
-        })
-    })
-
-    describe('memory', () => {
-        let originalFinalizationRegistry: FinalizationRegistry
-        let cleanupMemory = (ref: any) => {}
-
-        beforeEach(() => {
-            originalFinalizationRegistry = FinalizationRegistry as any
-            window.FinalizationRegistry = function (cleanupCb: (heldValue: any) => void) {
-                const heldValueSet = new Map()
-
-                cleanupMemory = ref => {
-                    const heldValue = heldValueSet.get(ref)
-
-                    cleanupCb(heldValue)
-                }
-
-                return ({
-                    register(target: object, heldValue: any, unregisterToken?: object) {
-                        heldValueSet.set(target, heldValue)
-                    },
-                    unregister() {}
-                } as unknown) as FinalizationRegistry
-            } as any
+        beforeAll(() => {
+            originalWeakRef = global.WeakRef
+            // @ts-ignore
+            global.WeakRef = undefined
+            originalFinalizationRegistry = global.FinalizationRegistry
+            // @ts-ignore
+            global.FinalizationRegistry = undefined
         })
 
-        afterEach(() => {
-            window.FinalizationRegistry = originalFinalizationRegistry as any
+        afterAll(() => {
+            if (originalWeakRef && originalFinalizationRegistry) {
+                global.WeakRef = originalWeakRef
+                originalWeakRef = undefined
+
+                global.FinalizationRegistry = originalFinalizationRegistry
+                originalFinalizationRegistry = undefined
+            }
         })
 
-        it('should be auto cleaned when ref in Map is freeing in program', function () {
-            const iwm = new IterableWeakMap()
-            const ref = {}
-            const value = {}
-            const ref2 = {}
-            const value2 = {}
-
-            iwm.set(ref, value)
-            iwm.set(ref2, value2)
-
-            expect(iwm.size).toBe(2)
-            expect(Array.from(iwm.entries())).toEqual([
-                [ref, value],
-                [ref2, value2]
-            ])
-
-            // emulate freeing "ref" in memory
-            cleanupMemory(ref)
-
-            expect(iwm.size).toBe(1)
-            expect(Array.from(iwm.entries())).toEqual([[ref2, value2]])
-        })
+        runCommonTests()
     })
 })

--- a/test/IterableWeakMap.spec.ts
+++ b/test/IterableWeakMap.spec.ts
@@ -1,0 +1,182 @@
+import { IterableWeakMap } from '../src/IterableWeakMap'
+
+describe('IterableWeakMap', () => {
+    describe('#set', () => {
+        it('should add new value', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+
+            iwm.set(ref, value)
+
+            const entries = Array.from(iwm.entries())
+            expect(entries).toEqual([[ref, value]])
+        })
+    })
+
+    describe('#get', () => {
+        it('should return value if ref exists in Map', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+
+            iwm.set(ref, value)
+
+            const getValue = iwm.get(ref)
+            expect(getValue).toEqual(value)
+        })
+
+        it("should return undefined if ref doesn't exist in Map", function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+            const ref2 = {}
+
+            iwm.set(ref, value)
+
+            const getValue = iwm.get(ref2)
+            expect(getValue).toBeUndefined()
+        })
+    })
+
+    describe('#delete', () => {
+        it('should delete value from Map', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+
+            iwm.set(ref, value)
+
+            iwm.delete(ref)
+
+            expect(iwm.size).toBe(0)
+        })
+    })
+
+    describe('#size', () => {
+        it('should return size of Map', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+            const ref2 = {}
+            const value2 = {}
+
+            iwm.set(ref, value)
+            iwm.set(ref2, value2)
+
+            expect(iwm.size).toBe(2)
+        })
+    })
+
+    describe('#has', () => {
+        it('should return true if map has ref', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+
+            iwm.set(ref, value)
+
+            expect(iwm.has(ref)).toBe(true)
+        })
+
+        it("should return false if map doesn't have ref", function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+            const ref2 = {}
+
+            iwm.set(ref, value)
+
+            expect(iwm.has(ref2)).toBe(false)
+        })
+    })
+
+    describe('#clear', () => {
+        it('should delete all refs from Map', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+            const ref2 = {}
+            const value2 = {}
+
+            iwm.set(ref, value)
+            iwm.set(ref2, value2)
+
+            expect(iwm.size).toBe(2)
+
+            iwm.clear()
+
+            expect(iwm.size).toBe(0)
+        })
+    })
+
+    describe('#forEach', () => {
+        it('should iterate over all entries in Map', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+            const ref2 = {}
+            const value2 = {}
+
+            iwm.set(ref, value)
+            iwm.set(ref2, value2)
+
+            const res: [object, object, IterableWeakMap<any, any>][] = []
+
+            iwm.forEach((v, k, map) => {
+                res.push([v, k, map])
+            })
+
+            expect(res).toEqual([
+                [ref, value, iwm],
+                [ref2, value2, iwm]
+            ])
+        })
+    })
+
+    describe('memory', () => {
+        let cleanupMemory = (ref: any) => {}
+
+        beforeEach(() => {
+            window.FinalizationRegistry = function (cleanupCb: (heldValue: any) => void) {
+                const heldValueSet = new Map()
+
+                cleanupMemory = ref => {
+                    const heldValue = heldValueSet.get(ref)
+
+                    cleanupCb(heldValue)
+                }
+
+                return ({
+                    register(target: object, heldValue: any, unregisterToken?: object) {
+                        heldValueSet.set(target, heldValue)
+                    },
+                    unregister() {}
+                } as unknown) as FinalizationRegistry
+            } as any
+        })
+
+        it('should be cleaned when there is not refs to Map key', function () {
+            const iwm = new IterableWeakMap()
+            const ref = {}
+            const value = {}
+            const ref2 = {}
+            const value2 = {}
+
+            iwm.set(ref, value)
+            iwm.set(ref2, value2)
+
+            expect(iwm.size).toBe(2)
+            expect(Array.from(iwm.entries())).toEqual([
+                [ref, value],
+                [ref2, value2]
+            ])
+
+            // emulate freeing "ref" in memory
+            cleanupMemory(ref)
+
+            expect(iwm.size).toBe(1)
+            expect(Array.from(iwm.entries())).toEqual([[ref2, value2]])
+        })
+    })
+})

--- a/test/IterableWeakMap.spec.ts
+++ b/test/IterableWeakMap.spec.ts
@@ -261,10 +261,10 @@ describe('IterableWeakMap', () => {
         beforeAll(() => {
             originalWeakRef = global.WeakRef
             // @ts-ignore
-            global.WeakRef = undefined
+            delete global.WeakRef
             originalFinalizationRegistry = global.FinalizationRegistry
             // @ts-ignore
-            global.FinalizationRegistry = undefined
+            delete global.FinalizationRegistry
         })
 
         afterAll(() => {

--- a/test/IterableWeakMap.spec.ts
+++ b/test/IterableWeakMap.spec.ts
@@ -156,7 +156,7 @@ describe('IterableWeakMap', () => {
             } as any
         })
 
-        it('should be cleaned when there is not refs to Map key', function () {
+        it('should be auto cleaned when ref in Map is freeing in program', function () {
             const iwm = new IterableWeakMap()
             const ref = {}
             const value = {}


### PR DESCRIPTION
Today anytime when memoizeForState is used, it creates a memoized function that is live forever in memory.
This PR introduce WeakMap storage for memoized function(instead of array), they will be cleared whenever memoized function will be GC.

IterableWeakMap example is taken from https://github.com/tc39/proposal-weakrefs#iterable-weakmaps

Note: IterableWeakMap uses [FinalizationRegistry](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry#browser_compatibility) and [WeakRef](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef#browser_compatibility) that **are not** supported by all browsers.

