### PR TITLE
Notify observers before the subscribers on state update

### DIFF
--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -192,8 +192,8 @@ export const createThrottledStore = (
 
     const notifyAll = () => {
         try {
-            notifySubscribers()
             notifyObservers()
+            notifySubscribers()
         } finally {
             resetAllPendingNotifications()
         }


### PR DESCRIPTION
Call `notifyObservers` before we call `notifySubscribers`, so when `notifySubscribers` is called we would already have the updated observers.