### PR TITLE
observeWithShell for pure component

### DIFF
--- a/src/connectWithShell.tsx
+++ b/src/connectWithShell.tsx
@@ -242,17 +242,6 @@ function createObservableConnectedComponentFactory<S, OM extends ObservablesMap,
 export function observeWithShell<OM extends ObservablesMap, OP extends ObservedSelectorsMap<OM>>(
     observables: OM,
     boundShell: Shell
-): <S, SP, DP>(
-    innerFactory: ConnectedComponentFactory<S, OP, SP, DP>
-) => ConnectedComponentFactory<S, OmitObservedSelectors<OP, OM>, SP, DP, OP> {
-    return <S, SP, DP>(innerFactory: ConnectedComponentFactory<S, OP, SP, DP>) => {
-        return createObservableConnectedComponentFactory(observables, boundShell, innerFactory)
-    }
-}
-
-export function observeWithShellPureComponent<OM extends ObservablesMap, OP extends ObservedSelectorsMap<OM>>(
-    observables: OM,
-    boundShell: Shell
 ): ConnectedComponentFactory<{}, OmitObservedSelectors<OP, OM>, {}, {}, OP> {
     return createObservableConnectedComponentFactory(observables, boundShell)
 }
@@ -265,6 +254,17 @@ export function connectWithShellAndObserve<OM extends ObservablesMap, OP extends
     options: ConnectWithShellOptions = {}
 ): ConnectedComponentFactory<S, OmitObservedSelectors<OP, OM>, SP, DP, OP> {
     const innerFactory = connectWithShell(mapStateToProps, mapDispatchToProps, boundShell, options)
-    const wrapperFactory = observeWithShell<OM, OP>(observables, boundShell)(innerFactory)
+    const wrapperFactory = observeConnectedComponentWithShell<OM, OP>(observables, boundShell)(innerFactory)
     return wrapperFactory
+}
+
+function observeConnectedComponentWithShell<OM extends ObservablesMap, OP extends ObservedSelectorsMap<OM>>(
+    observables: OM,
+    boundShell: Shell
+): <S, SP, DP>(
+    innerFactory: ConnectedComponentFactory<S, OP, SP, DP>
+) => ConnectedComponentFactory<S, OmitObservedSelectors<OP, OM>, SP, DP, OP> {
+    return <S, SP, DP>(innerFactory: ConnectedComponentFactory<S, OP, SP, DP>) => {
+        return createObservableConnectedComponentFactory(observables, boundShell, innerFactory)
+    }
 }

--- a/src/connectWithShell.tsx
+++ b/src/connectWithShell.tsx
@@ -184,6 +184,61 @@ export function mapObservablesToSelectors<M extends ObservablesMap>(map: M): Obs
     return result
 }
 
+function createObservableConnectedComponentFactory<S, OM extends ObservablesMap, OP extends ObservedSelectorsMap<OM>, SP, DP>(
+    observables: OM,
+    boundShell: Shell,
+    innerFactory?: ConnectedComponentFactory<S, OP, SP, DP>
+): ConnectedComponentFactory<S, OmitObservedSelectors<OP, OM>, SP, DP, OP> {
+    type ObservableWrapperProps = OmitObservedSelectors<OP, OM>
+    type ObservableWrapperState = ObservedSelectorsMap<OM>
+
+    const observableConnectedComponentFactory: ConnectedComponentFactory<S, ObservableWrapperProps, SP, DP, OP> = pureComponent => {
+        class ObservableWrapperComponent extends React.Component<ObservableWrapperProps, ObservableWrapperState> {
+            public connectedComponent: React.ComponentType<any>
+            public unsubscribes: StateObserverUnsubscribe[]
+
+            constructor(props: OP) {
+                super(props)
+                this.connectedComponent = innerFactory ? innerFactory(pureComponent) : pureComponent
+                this.unsubscribes = []
+                this.state = mapObservablesToSelectors(observables)
+            }
+
+            public componentDidMount() {
+                for (const key in observables) {
+                    const unsubscribe = observables[key].subscribe(boundShell, () => {
+                        const newState = mapObservablesToSelectors(observables)
+                        this.setState(newState)
+                    })
+                    this.unsubscribes.push(unsubscribe)
+                }
+            }
+
+            public componentWillUnmount() {
+                this.unsubscribes.forEach(unsubscribe => unsubscribe())
+                this.unsubscribes = []
+            }
+
+            public render() {
+                const ConnectedComponent = this.connectedComponent
+                const connectedComponentProps: OP = {
+                    ...this.props, // OP excluding observed selectors
+                    ...this.state // observed selectors
+                } as OP // TypeScript doesn't get it
+                return <ConnectedComponent {...connectedComponentProps} />
+            }
+        }
+
+        const hoc = (props: WithChildren<OmitObservedSelectors<OP, OM>>) => {
+            return <ObservableWrapperComponent {...props} {...mapObservablesToSelectors(observables)} />
+        }
+
+        return hoc
+    }
+
+    return observableConnectedComponentFactory
+}
+
 export function observeWithShell<OM extends ObservablesMap, OP extends ObservedSelectorsMap<OM>>(
     observables: OM,
     boundShell: Shell
@@ -191,56 +246,15 @@ export function observeWithShell<OM extends ObservablesMap, OP extends ObservedS
     innerFactory: ConnectedComponentFactory<S, OP, SP, DP>
 ) => ConnectedComponentFactory<S, OmitObservedSelectors<OP, OM>, SP, DP, OP> {
     return <S, SP, DP>(innerFactory: ConnectedComponentFactory<S, OP, SP, DP>) => {
-        // exclude observed selectors from wrapper props, because we want those selectors to be in the wrapper's state instead
-        type ObservableWrapperProps = OmitObservedSelectors<OP, OM>
-        type ObservableWrapperState = ObservedSelectorsMap<OM>
-
-        const observableConnectedComponentFactory: ConnectedComponentFactory<S, ObservableWrapperProps, SP, DP, OP> = pureComponent => {
-            class ObservableWrapperComponent extends React.Component<ObservableWrapperProps, ObservableWrapperState> {
-                public connectedComponent: React.ComponentType<OP>
-                public unsubscribes: StateObserverUnsubscribe[]
-
-                constructor(props: OP) {
-                    super(props)
-                    this.connectedComponent = innerFactory(pureComponent)
-                    this.unsubscribes = []
-                    this.state = mapObservablesToSelectors(observables)
-                }
-
-                public componentDidMount() {
-                    for (const key in observables) {
-                        const unsubscribe = observables[key].subscribe(boundShell, () => {
-                            const newState = mapObservablesToSelectors(observables)
-                            this.setState(newState)
-                        })
-                        this.unsubscribes.push(unsubscribe)
-                    }
-                }
-
-                public componentWillUnmount() {
-                    this.unsubscribes.forEach(unsubscribe => unsubscribe())
-                    this.unsubscribes = []
-                }
-
-                public render() {
-                    const ConnectedComponent = this.connectedComponent
-                    const connectedComponentProps: OP = {
-                        ...this.props, // OP excluding observed selectors
-                        ...this.state // observed selectors
-                    } as OP // TypeScript doesn't get it
-                    return <ConnectedComponent {...connectedComponentProps} />
-                }
-            }
-
-            const hoc = (props: WithChildren<OmitObservedSelectors<OP, OM>>) => {
-                return <ObservableWrapperComponent {...props} {...mapObservablesToSelectors(observables)} />
-            }
-
-            return hoc
-        }
-
-        return observableConnectedComponentFactory
+        return createObservableConnectedComponentFactory(observables, boundShell, innerFactory)
     }
+}
+
+export function observeWithShellPureComponent<OM extends ObservablesMap, OP extends ObservedSelectorsMap<OM>>(
+    observables: OM,
+    boundShell: Shell
+): ConnectedComponentFactory<{}, OmitObservedSelectors<OP, OM>, {}, {}, OP> {
+    return createObservableConnectedComponentFactory(observables, boundShell)
 }
 
 export function connectWithShellAndObserve<OM extends ObservablesMap, OP extends ObservedSelectorsMap<OM>, S = {}, SP = {}, DP = {}>(

--- a/test/connectWithShell.spec.tsx
+++ b/test/connectWithShell.spec.tsx
@@ -412,86 +412,86 @@ describe('connectWithShell', () => {
 })
 
 describe('connectWithShell-useCases', () => {
-    interface TestStateOne {
-        one: { valueOne: string }
+    interface FirstState {
+        firstState: { valueOne: string }
     }
-    interface TestStateTwo {
-        two: { valueTwo: string }
+    interface SecondState {
+        secondState: { valueTwo: string }
     }
-    interface TestStateThree {
-        three: { valueThree: string }
+    interface FirstObservableState {
+        firstObservable: { valueThree: string }
     }
-    interface TestStateFour {
-        four: { valueFour: string }
+    interface SecondObservableState {
+        secondObservable: { valueFour: string }
     }
 
-    interface TwoAPI {
+    interface SecondStateAPI {
         getValueTwo(): string
     }
-    const TwoAPI: SlotKey<TwoAPI> = { name: 'TWO_API', public: true }
+    const SecondStateAPI: SlotKey<SecondStateAPI> = { name: 'TWO_API', public: true }
 
-    interface ThreeAPI {
-        observables: { three: ObservableState<ThreeAPISelectors> }
+    interface FirstObservableAPI {
+        observables: { three: ObservableState<FirstObservableSelectors> }
     }
-    interface ThreeAPISelectors {
+    interface FirstObservableSelectors {
         getValueThree(): string
     }
-    const ThreeAPI: SlotKey<ThreeAPI> = { name: 'THREE_API', public: true }
+    const FirstObservableAPI: SlotKey<FirstObservableAPI> = { name: 'THREE_API', public: true }
 
-    interface FourAPI {
-        observables: { four: ObservableState<FourAPISelectors> }
+    interface SecondObservableAPI {
+        observables: { four: ObservableState<SecondObservableSelectors> }
     }
-    interface FourAPISelectors {
+    interface SecondObservableSelectors {
         getValueFour(): string
     }
-    const FourAPI: SlotKey<FourAPI> = { name: 'FOUR_API', public: true }
+    const SecondObservableAPI: SlotKey<SecondObservableAPI> = { name: 'FOUR_API', public: true }
 
-    const entryPointOne: EntryPoint = {
+    const entryPointWithState: EntryPoint = {
         name: 'ONE',
-        getDependencyAPIs: () => [TwoAPI],
+        getDependencyAPIs: () => [SecondStateAPI],
         attach(shell) {
-            shell.contributeState<TestStateOne>(() => ({
-                one: (state = { valueOne: 'init1' }, action) => {
-                    return action.type === 'SET_ONE' ? { valueOne: action.value } : state
+            shell.contributeState<FirstState>(() => ({
+                firstState: (state = { valueOne: 'init1' }, action) => {
+                    return action.type === 'SET_FIRST_STATE' ? { valueOne: action.value } : state
                 }
             }))
         }
     }
 
-    const entryPointTwo: EntryPoint = {
+    const entryPointSecondStateWithAPI: EntryPoint = {
         name: 'TWO',
-        declareAPIs: () => [TwoAPI],
+        declareAPIs: () => [SecondStateAPI],
         attach(shell) {
-            shell.contributeState<TestStateTwo>(() => ({
-                two: (state = { valueTwo: 'init2' }, action) => {
-                    return action.type === 'SET_TWO' ? { valueTwo: action.value } : state
+            shell.contributeState<SecondState>(() => ({
+                secondState: (state = { valueTwo: 'init2' }, action) => {
+                    return action.type === 'SET_SECOND_STATE' ? { valueTwo: action.value } : state
                 }
             }))
-            shell.contributeAPI(TwoAPI, () => ({
+            shell.contributeAPI(SecondStateAPI, () => ({
                 getValueTwo() {
-                    return shell.getStore<TestStateTwo>().getState().two.valueTwo
+                    return shell.getStore<SecondState>().getState().secondState.valueTwo
                 }
             }))
         }
     }
 
-    const entryPointThree: EntryPoint = {
+    const entryPointFirstObservable: EntryPoint = {
         name: 'THREE',
-        declareAPIs: () => [ThreeAPI],
+        declareAPIs: () => [FirstObservableAPI],
         attach(shell) {
-            const observableThree = shell.contributeObservableState<TestStateThree, ThreeAPISelectors>(
+            const observableThree = shell.contributeObservableState<FirstObservableState, FirstObservableSelectors>(
                 () => ({
-                    three: (state = { valueThree: 'init3' }, action) => {
-                        return action.type === 'SET_THREE' ? { valueThree: action.value } : state
+                    firstObservable: (state = { valueThree: 'init3' }, action) => {
+                        return action.type === 'SET_FIRST_OBSERVABLE' ? { valueThree: action.value } : state
                     }
                 }),
                 state => {
                     return {
-                        getValueThree: () => state.three.valueThree
+                        getValueThree: () => state.firstObservable.valueThree
                     }
                 }
             )
-            shell.contributeAPI(ThreeAPI, () => ({
+            shell.contributeAPI(FirstObservableAPI, () => ({
                 observables: {
                     three: observableThree
                 }
@@ -499,23 +499,23 @@ describe('connectWithShell-useCases', () => {
         }
     }
 
-    const entryPointFour: EntryPoint = {
+    const entryPointSecondObservable: EntryPoint = {
         name: 'Four',
-        declareAPIs: () => [FourAPI],
+        declareAPIs: () => [SecondObservableAPI],
         attach(shell) {
-            const observableFour = shell.contributeObservableState<TestStateFour, FourAPISelectors>(
+            const observableFour = shell.contributeObservableState<SecondObservableState, SecondObservableSelectors>(
                 () => ({
-                    four: (state = { valueFour: 'init4' }, action) => {
-                        return action.type === 'SET_FOUR' ? { valueFour: action.value } : state
+                    secondObservable: (state = { valueFour: 'init4' }, action) => {
+                        return action.type === 'SET_SECOND_OBSERVABLE' ? { valueFour: action.value } : state
                     }
                 }),
                 state => {
                     return {
-                        getValueFour: () => state.four.valueFour
+                        getValueFour: () => state.secondObservable.valueFour
                     }
                 }
             )
-            shell.contributeAPI(FourAPI, () => ({
+            shell.contributeAPI(SecondObservableAPI, () => ({
                 observables: {
                     four: observableFour
                 }
@@ -553,11 +553,11 @@ describe('connectWithShell-useCases', () => {
             </div>
         )
     }
-    const mapStateToProps = (shell: Shell, state: TestStateOne): CompProps => {
+    const mapStateToProps = (shell: Shell, state: FirstState): CompProps => {
         mapStateToPropsSpy()
         return {
-            valueOne: state.one.valueOne,
-            valueTwo: shell.getAPI(TwoAPI).getValueTwo(),
+            valueOne: state.firstState.valueOne,
+            valueTwo: shell.getAPI(SecondStateAPI).getValueTwo(),
             valueThree: ''
         }
     }
@@ -568,33 +568,33 @@ describe('connectWithShell-useCases', () => {
     })
 
     it('should include observable state in store', () => {
-        const { shell } = createMocks(entryPointThree)
+        const { shell } = createMocks(entryPointFirstObservable)
 
-        const state = shell.getStore<TestStateThree>().getState()
+        const state = shell.getStore<FirstObservableState>().getState()
 
         expect(state).toBeDefined()
-        expect(state.three.valueThree).toBe('init3')
+        expect(state.firstObservable.valueThree).toBe('init3')
     })
 
     it('should dispatch actions to observable reducers', () => {
-        const { shell } = createMocks(entryPointThree)
+        const { shell } = createMocks(entryPointFirstObservable)
 
-        shell.getStore<TestStateThree>().dispatch({ type: 'SET_THREE', value: 'updated_by_test' })
+        shell.getStore<FirstObservableState>().dispatch({ type: 'SET_FIRST_OBSERVABLE', value: 'updated_by_test' })
 
-        const state = shell.getStore<TestStateThree>().getState()
-        expect(state.three.valueThree).toEqual('updated_by_test')
+        const state = shell.getStore<FirstObservableState>().getState()
+        expect(state.firstObservable.valueThree).toEqual('updated_by_test')
     })
 
     it('should invoke subscribed callback when observed state changes', () => {
-        const { shell } = createMocks(entryPointThree)
+        const { shell } = createMocks(entryPointFirstObservable)
 
-        const receivedSelectors: ThreeAPISelectors[] = []
-        shell.getAPI(ThreeAPI).observables.three.subscribe(shell, next => {
+        const receivedSelectors: FirstObservableSelectors[] = []
+        shell.getAPI(FirstObservableAPI).observables.three.subscribe(shell, next => {
             receivedSelectors.push(next)
         })
 
-        const { dispatch, flush } = shell.getStore<TestStateThree>()
-        dispatch({ type: 'SET_THREE', value: 'updated_by_test' })
+        const { dispatch, flush } = shell.getStore<FirstObservableState>()
+        dispatch({ type: 'SET_FIRST_OBSERVABLE', value: 'updated_by_test' })
         flush()
 
         expect(receivedSelectors.length).toBe(1)
@@ -613,7 +613,7 @@ describe('connectWithShell-useCases', () => {
     })
 
     it('should not mount connected component on props update', () => {
-        const { host, shell, renderInShellContext } = createMocks(entryPointOne, [entryPointTwo])
+        const { host, shell, renderInShellContext } = createMocks(entryPointWithState, [entryPointSecondStateWithAPI])
         const ConnectedComp = connectWithShell(mapStateToProps, undefined, shell, { allowOutOfEntryPoint: true })(PureComp)
         const { root } = renderInShellContext(<ConnectedComp />)
         if (!root) {
@@ -623,14 +623,14 @@ describe('connectWithShell-useCases', () => {
         expect(renderSpy).toHaveBeenCalledTimes(1)
         expect(mountSpy).toHaveBeenCalledTimes(1)
 
-        dispatchAndFlush({ type: 'SET_ONE', value: 'update1' }, host)
+        dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update1' }, host)
 
         expect(renderSpy).toHaveBeenCalledTimes(2)
         expect(mountSpy).toHaveBeenCalledTimes(1)
     })
 
     it('should update component on change in regular state', () => {
-        const { host, shell, renderInShellContext } = createMocks(entryPointOne, [entryPointTwo])
+        const { host, shell, renderInShellContext } = createMocks(entryPointWithState, [entryPointSecondStateWithAPI])
         const ConnectedComp = connectWithShell(mapStateToProps, undefined, shell, { allowOutOfEntryPoint: true })(PureComp)
 
         const { root } = renderInShellContext(<ConnectedComp />)
@@ -643,14 +643,14 @@ describe('connectWithShell-useCases', () => {
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
-        dispatchAndFlush({ type: 'SET_ONE', value: 'update1' }, host)
+        dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update1' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
 
-        dispatchAndFlush({ type: 'SET_TWO', value: 'update2' }, host)
+        dispatchAndFlush({ type: 'SET_SECOND_STATE', value: 'update2' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('update2')
@@ -666,7 +666,10 @@ describe('connectWithShell-useCases', () => {
     })
 
     it('should not update uninterested component on change in observable state', () => {
-        const { host, shell, renderInShellContext } = createMocks(entryPointOne, [entryPointTwo, entryPointThree])
+        const { host, shell, renderInShellContext } = createMocks(entryPointWithState, [
+            entryPointSecondStateWithAPI,
+            entryPointFirstObservable
+        ])
         const ConnectedComp = connectWithShell(mapStateToProps, undefined, shell, { allowOutOfEntryPoint: true })(PureComp)
 
         const { root } = renderInShellContext(<ConnectedComp />)
@@ -679,7 +682,7 @@ describe('connectWithShell-useCases', () => {
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
-        dispatchAndFlush({ type: 'SET_ONE', value: 'update1' }, host)
+        dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update1' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
@@ -687,7 +690,7 @@ describe('connectWithShell-useCases', () => {
         expect(renderSpy).toHaveBeenCalledTimes(2)
 
         // this should not notify the uninterested component
-        dispatchAndFlush({ type: 'SET_THREE', value: 'update3' }, host)
+        dispatchAndFlush({ type: 'SET_FIRST_OBSERVABLE', value: 'update3' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
@@ -696,20 +699,20 @@ describe('connectWithShell-useCases', () => {
     })
 
     it('should update component through observer', () => {
-        const { host, shell, renderInShellContext } = createMocks(withDependencyAPIs(entryPointOne, [ThreeAPI]), [
-            entryPointTwo,
-            entryPointThree
+        const { host, shell, renderInShellContext } = createMocks(withDependencyAPIs(entryPointWithState, [FirstObservableAPI]), [
+            entryPointSecondStateWithAPI,
+            entryPointFirstObservable
         ])
 
         const ConnectedComp = connectWithShellAndObserve(
             {
-                observedThree: host.getAPI(ThreeAPI).observables.three
+                observedThree: host.getAPI(FirstObservableAPI).observables.three
             },
-            (_shell, state: TestStateOne, ownProps): CompProps => {
+            (_shell, state: FirstState, ownProps): CompProps => {
                 mapStateToPropsSpy()
                 return {
-                    valueOne: state.one.valueOne,
-                    valueTwo: _shell.getAPI(TwoAPI).getValueTwo(),
+                    valueOne: state.firstState.valueOne,
+                    valueTwo: _shell.getAPI(SecondStateAPI).getValueTwo(),
                     valueThree: ownProps?.observedThree.getValueThree() || 'N/A'
                 }
             },
@@ -730,7 +733,7 @@ describe('connectWithShell-useCases', () => {
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
-        dispatchAndFlush({ type: 'SET_ONE', value: 'update1' }, host)
+        dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update1' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
@@ -738,7 +741,7 @@ describe('connectWithShell-useCases', () => {
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
 
-        dispatchAndFlush({ type: 'SET_THREE', value: 'update3' }, host)
+        dispatchAndFlush({ type: 'SET_FIRST_OBSERVABLE', value: 'update3' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
@@ -756,12 +759,14 @@ describe('connectWithShell-useCases', () => {
     })
 
     it('should update only the relevant observing components', () => {
-        const { host, shell, renderInShellContext } = createMocks(withDependencyAPIs(entryPointThree, [FourAPI]), [entryPointFour])
+        const { host, shell, renderInShellContext } = createMocks(withDependencyAPIs(entryPointFirstObservable, [SecondObservableAPI]), [
+            entryPointSecondObservable
+        ])
 
         const firstMapStateToPropsSpy = jest.fn()
         const FirstConnectedComp = connectWithShellAndObserve(
             {
-                observedThree: host.getAPI(ThreeAPI).observables.three
+                observedThree: host.getAPI(FirstObservableAPI).observables.three
             },
             (_shell, state, ownProps): CompProps => {
                 firstMapStateToPropsSpy()
@@ -779,7 +784,7 @@ describe('connectWithShell-useCases', () => {
         const secondMapStateToPropsSpy = jest.fn()
         const SecondConnectedComp = connectWithShellAndObserve(
             {
-                observedFour: host.getAPI(FourAPI).observables.four
+                observedFour: host.getAPI(SecondObservableAPI).observables.four
             },
             (_shell, state, ownProps): CompProps => {
                 secondMapStateToPropsSpy()
@@ -810,7 +815,7 @@ describe('connectWithShell-useCases', () => {
         expect(firstMapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(secondMapStateToPropsSpy).toHaveBeenCalledTimes(1)
 
-        dispatchAndFlush({ type: 'SET_THREE', value: 'update3' }, host)
+        dispatchAndFlush({ type: 'SET_FIRST_OBSERVABLE', value: 'update3' }, host)
 
         expect(root.find(FirstConnectedComp).find('#THREE').text()).toBe('update3')
         expect(root.find(SecondConnectedComp).find('#THREE').text()).toBe('init4')
@@ -818,7 +823,7 @@ describe('connectWithShell-useCases', () => {
         expect(firstMapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(secondMapStateToPropsSpy).toHaveBeenCalledTimes(1)
 
-        dispatchAndFlush({ type: 'SET_FOUR', value: 'update4' }, host)
+        dispatchAndFlush({ type: 'SET_SECOND_OBSERVABLE', value: 'update4' }, host)
 
         expect(root.find(FirstConnectedComp).find('#THREE').text()).toBe('update3')
         expect(root.find(SecondConnectedComp).find('#THREE').text()).toBe('update4')

--- a/test/connectWithShell.spec.tsx
+++ b/test/connectWithShell.spec.tsx
@@ -15,7 +15,7 @@ import {
 import { mount, ReactWrapper } from 'enzyme'
 import { AnyAction } from 'redux'
 import { TOGGLE_MOCK_VALUE } from '../testKit/mockPackage'
-import { ObservedSelectorsMap, observeWithShellPureComponent } from '../src'
+import { ObservedSelectorsMap, observeWithShell } from '../src'
 
 interface MockPackageState {
     [mockShellStateKey]: MockState
@@ -42,6 +42,11 @@ const createMocks = (entryPoint: EntryPoint, moreEntryPoints: EntryPoint[] = [])
         shell: getShell(),
         renderInShellContext: (reactElement: ReactElement<any>) => renderInHost(reactElement, host, getShell())
     }
+}
+
+const dispatchAndFlush = (action: AnyAction, { getStore }: AppHost) => {
+    getStore().dispatch(action)
+    getStore().flush()
 }
 
 describe('connectWithShell', () => {
@@ -562,12 +567,6 @@ describe('connectWithShell-useCases', () => {
         mapStateToPropsSpy.mockClear()
     })
 
-    const handleAction = (action: AnyAction, dom: ReactWrapper, { getStore }: AppHost) => {
-        getStore().dispatch(action)
-        getStore().flush()
-        //dom.update()
-    }
-
     it('should include observable state in store', () => {
         const { shell } = createMocks(entryPointThree)
 
@@ -624,7 +623,7 @@ describe('connectWithShell-useCases', () => {
         expect(renderSpy).toHaveBeenCalledTimes(1)
         expect(mountSpy).toHaveBeenCalledTimes(1)
 
-        handleAction({ type: 'SET_ONE', value: 'update1' }, root, host)
+        dispatchAndFlush({ type: 'SET_ONE', value: 'update1' }, host)
 
         expect(renderSpy).toHaveBeenCalledTimes(2)
         expect(mountSpy).toHaveBeenCalledTimes(1)
@@ -644,21 +643,21 @@ describe('connectWithShell-useCases', () => {
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
-        handleAction({ type: 'SET_ONE', value: 'update1' }, root, host)
+        dispatchAndFlush({ type: 'SET_ONE', value: 'update1' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
 
-        handleAction({ type: 'SET_TWO', value: 'update2' }, root, host)
+        dispatchAndFlush({ type: 'SET_TWO', value: 'update2' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('update2')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(3)
         expect(renderSpy).toHaveBeenCalledTimes(3)
 
-        handleAction({ type: 'SOME_OTHER_ACTION' }, root, host)
+        dispatchAndFlush({ type: 'SOME_OTHER_ACTION' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('update2')
@@ -680,7 +679,7 @@ describe('connectWithShell-useCases', () => {
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
-        handleAction({ type: 'SET_ONE', value: 'update1' }, root, host)
+        dispatchAndFlush({ type: 'SET_ONE', value: 'update1' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
@@ -688,7 +687,7 @@ describe('connectWithShell-useCases', () => {
         expect(renderSpy).toHaveBeenCalledTimes(2)
 
         // this should not notify the uninterested component
-        handleAction({ type: 'SET_THREE', value: 'update3' }, root, host)
+        dispatchAndFlush({ type: 'SET_THREE', value: 'update3' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
@@ -731,7 +730,7 @@ describe('connectWithShell-useCases', () => {
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
-        handleAction({ type: 'SET_ONE', value: 'update1' }, root, host)
+        dispatchAndFlush({ type: 'SET_ONE', value: 'update1' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
@@ -739,7 +738,7 @@ describe('connectWithShell-useCases', () => {
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
 
-        handleAction({ type: 'SET_THREE', value: 'update3' }, root, host)
+        dispatchAndFlush({ type: 'SET_THREE', value: 'update3' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
@@ -747,7 +746,7 @@ describe('connectWithShell-useCases', () => {
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(3)
         expect(renderSpy).toHaveBeenCalledTimes(3)
 
-        handleAction({ type: 'SOME_OTHER_ACTION' }, root, host)
+        dispatchAndFlush({ type: 'SOME_OTHER_ACTION' }, host)
 
         expect(root.find(ConnectedComp).find('#ONE').text()).toBe('update1')
         expect(root.find(ConnectedComp).find('#TWO').text()).toBe('init2')
@@ -811,7 +810,7 @@ describe('connectWithShell-useCases', () => {
         expect(firstMapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(secondMapStateToPropsSpy).toHaveBeenCalledTimes(1)
 
-        handleAction({ type: 'SET_THREE', value: 'update3' }, root, host)
+        dispatchAndFlush({ type: 'SET_THREE', value: 'update3' }, host)
 
         expect(root.find(FirstConnectedComp).find('#THREE').text()).toBe('update3')
         expect(root.find(SecondConnectedComp).find('#THREE').text()).toBe('init4')
@@ -819,7 +818,7 @@ describe('connectWithShell-useCases', () => {
         expect(firstMapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(secondMapStateToPropsSpy).toHaveBeenCalledTimes(1)
 
-        handleAction({ type: 'SET_FOUR', value: 'update4' }, root, host)
+        dispatchAndFlush({ type: 'SET_FOUR', value: 'update4' }, host)
 
         expect(root.find(FirstConnectedComp).find('#THREE').text()).toBe('update3')
         expect(root.find(SecondConnectedComp).find('#THREE').text()).toBe('update4')
@@ -881,11 +880,6 @@ describe('observeWithShellPureComponent', () => {
         )
     }
 
-    const handleAction = (action: AnyAction, dom: ReactWrapper, { getStore }: AppHost) => {
-        getStore().dispatch(action)
-        getStore().flush()
-    }
-
     beforeEach(() => {
         renderSpyFunc.mockClear()
     })
@@ -907,7 +901,7 @@ describe('observeWithShellPureComponent', () => {
 
         const { host, shell, renderInShellContext } = createMocks(observableEntryPoint, [stateEntryPoint])
 
-        const ObservingComponent = observeWithShellPureComponent(
+        const ObservingComponent = observeWithShell(
             {
                 observable: host.getAPI(ObservableAPI).observable
             },
@@ -929,7 +923,7 @@ describe('observeWithShellPureComponent', () => {
     it('should update observing component', () => {
         const { host, shell, renderInShellContext } = createMocks(observableEntryPoint)
 
-        const ObservingComponent = observeWithShellPureComponent(
+        const ObservingComponent = observeWithShell(
             {
                 observable: host.getAPI(ObservableAPI).observable
             },
@@ -946,14 +940,14 @@ describe('observeWithShellPureComponent', () => {
 
         expect(renderSpyFunc).toHaveBeenCalledTimes(1)
 
-        handleAction({ type: 'SET_STRING', value: 'update' }, root, host)
+        dispatchAndFlush({ type: 'SET_STRING', value: 'update' }, host)
 
         expect(root.find(ObservingComponent).find('#OBSERVED_NUMBER').text()).toBe('1')
         expect(root.find(ObservingComponent).find('#OBSERVED_STRING').text()).toBe('update')
 
         expect(renderSpyFunc).toHaveBeenCalledTimes(2)
 
-        handleAction({ type: 'SET_NUMBER', value: '2' }, root, host)
+        dispatchAndFlush({ type: 'SET_NUMBER', value: '2' }, host)
 
         expect(root.find(ObservingComponent).find('#OBSERVED_NUMBER').text()).toBe('2')
         expect(root.find(ObservingComponent).find('#OBSERVED_STRING').text()).toBe('update')


### PR DESCRIPTION
Refactor `observeWithShell` to work with pure components, and add some tests