### PR TITLE
Prevent reading observables inside notifySubscribers

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -324,7 +324,7 @@ export type StateObserverUnsubscribe = () => void
 export type StateObserver<TSelectorAPI> = (next: TSelectorAPI) => void
 export interface ObservableState<TSelectorAPI> {
     subscribe(fromShell: Shell, callback: StateObserver<TSelectorAPI>): StateObserverUnsubscribe
-    current(): TSelectorAPI
+    current(allowUnsafeReading?: boolean): TSelectorAPI
 }
 
 export type AnyFunction = (...args: any[]) => any

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -956,8 +956,8 @@ miss: ${memoizedWithMissHit.miss}
                 })
                 const protectedObservable: PrivateObservableState<TState, TSelectorAPI> = {
                     subscribe: observable.subscribe,
-                    current: () => {
-                        if (IsStoreSubscribersNotifyInProgress) {
+                    current: (allowUnsafeReading?: boolean) => {
+                        if (IsStoreSubscribersNotifyInProgress && !allowUnsafeReading) {
                             throw new Error(
                                 `Should not read observable value during subscribers notify. ` +
                                     `If you wish to read the value, you component should be observing the value directly ` +

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -125,7 +125,7 @@ const verifyLayersUniqueness = (layers?: APILayer[] | APILayer[][]) => {
 export function createAppHost(initialEntryPointsOrPackages: EntryPointOrPackage[], options: AppHostOptions = { monitoring: {} }): AppHost {
     let store: PrivateThrottledStore | null = null
     let canInstallReadyEntryPoints: boolean = true
-    let IsStoreSubscribersNotifyInProgress = false
+    let isStoreSubscribersNotifyInProgress = false
 
     verifyLayersUniqueness(options.layers)
 
@@ -585,8 +585,8 @@ miss: ${memoizedWithMissHit.miss}
                 contributedState,
                 window.requestAnimationFrame,
                 window.cancelAnimationFrame,
-                isSubscriptionNotifyInProgress => {
-                    IsStoreSubscribersNotifyInProgress = isSubscriptionNotifyInProgress
+                notifySubscribersIsRunning => {
+                    isStoreSubscribersNotifyInProgress = notifySubscribersIsRunning
                 }
             )
             store.subscribe(() => {
@@ -957,11 +957,12 @@ miss: ${memoizedWithMissHit.miss}
                 const protectedObservable: PrivateObservableState<TState, TSelectorAPI> = {
                     subscribe: observable.subscribe,
                     current: (allowUnsafeReading?: boolean) => {
-                        if (IsStoreSubscribersNotifyInProgress && !allowUnsafeReading) {
+                        if (isStoreSubscribersNotifyInProgress && !allowUnsafeReading) {
                             throw new Error(
-                                `Should not read observable value during subscribers notify. ` +
-                                    `If you wish to read the value, you component should be observing the value directly ` +
-                                    `(using observeWithShell or connectWithShellAndObserve)`
+                                `Observer created by ${shell.name} current() function: ` +
+                                    'Should not read observable value during subscribers notify. ' +
+                                    'If you wish to read the value, you component should be observing the value directly ' +
+                                    '(using observeWithShell or connectWithShellAndObserve)'
                             )
                         }
                         return observable.current()

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -148,7 +148,8 @@ export const createThrottledStore = (
     host: AppHost & AppHostServicesProvider,
     contributedState: ExtensionSlot<StateContribution>,
     requestAnimationFrame: Window['requestAnimationFrame'],
-    cancelAnimationFrame: Window['cancelAnimationFrame']
+    cancelAnimationFrame: Window['cancelAnimationFrame'],
+    updateIsSubscriptionNotifyInProgress: (isSubscriptionNotifyInProgress: boolean) => void
 ): PrivateThrottledStore => {
     let pendingBroadcastNotification = false
     let pendingObservableNotifications: Set<AnyPrivateObservableState> | undefined
@@ -207,9 +208,11 @@ export const createThrottledStore = (
     const notifyAll = () => {
         try {
             notifyObservers()
+            updateIsSubscriptionNotifyInProgress(true)
             notifySubscribers()
         } finally {
             resetAllPendingNotifications()
+            updateIsSubscriptionNotifyInProgress(false)
         }
     }
 

--- a/test/connectWithShell.spec.tsx
+++ b/test/connectWithShell.spec.tsx
@@ -758,35 +758,14 @@ describe('connectWithShell-useCases', () => {
         expect(renderSpy).toHaveBeenCalledTimes(3)
     })
 
-    it('should throw if observable is read though API in mapStateToProps', () => {
-        const { host, shell, renderInShellContext } = createMocks(entryPointFirstObservable)
+    it('should throw if observable is read in store subscription', async () => {
+        const { host } = createMocks(withDependencyAPIs(entryPointSecondStateWithAPI, []), [entryPointFirstObservable])
 
-        const ConnectedComp = connectWithShellAndObserve(
-            {
-                observedThree: host.getAPI(FirstObservableAPI).observables.three
-            },
-            (_shell, state: FirstState, ownProps): CompProps => {
-                mapStateToPropsSpy()
-                return {
-                    valueOne: 'one',
-                    valueTwo: 'two',
-                    valueThree: host.getAPI(FirstObservableAPI).observables.three.current().getValueThree()
-                }
-            },
-            undefined,
-            shell,
-            { allowOutOfEntryPoint: true }
-        )(PureComp)
+        host.getStore().subscribe(() => {
+            host.getAPI(FirstObservableAPI).observables.three.current().getValueThree()
+        })
 
-        const { root } = renderInShellContext(<ConnectedComp />)
-        if (!root) {
-            throw new Error('Connected component failed to render')
-        }
-
-        expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
-        expect(renderSpy).toHaveBeenCalledTimes(1)
-
-        expect(() => dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update1' }, host)).toThrowError()
+        expect(() => dispatchAndFlush({ type: 'SET_SECOND_STATE', value: 'update2' }, host)).toThrowError()
     })
 
     it('should update only the relevant observing components', () => {

--- a/testKit/withThrowOnError.ts
+++ b/testKit/withThrowOnError.ts
@@ -2,6 +2,7 @@ import { AppHostOptions, HostLogger, LogSeverity, ShellLoggerSpan } from '../src
 
 export function withThrowOnError(options: AppHostOptions = { monitoring: {} }): AppHostOptions {
     const throwError = (error: Error, keyValuePairs?: Object) => {
+        console.error()
         throw new Error(`${error} ${keyValuePairs ? JSON.stringify(keyValuePairs) : ''}`)
     }
 
@@ -29,6 +30,7 @@ export function withThrowOnError(options: AppHostOptions = { monitoring: {} }): 
 
     return {
         ...options,
+        enableStickyErrorBoundaries: false,
         logger
     }
 }

--- a/testKit/withThrowOnError.ts
+++ b/testKit/withThrowOnError.ts
@@ -2,7 +2,6 @@ import { AppHostOptions, HostLogger, LogSeverity, ShellLoggerSpan } from '../src
 
 export function withThrowOnError(options: AppHostOptions = { monitoring: {} }): AppHostOptions {
     const throwError = (error: Error, keyValuePairs?: Object) => {
-        console.error()
         throw new Error(`${error} ${keyValuePairs ? JSON.stringify(keyValuePairs) : ''}`)
     }
 
@@ -30,7 +29,6 @@ export function withThrowOnError(options: AppHostOptions = { monitoring: {} }): 
 
     return {
         ...options,
-        enableStickyErrorBoundaries: false,
         logger
     }
 }


### PR DESCRIPTION
Throw an error when calling observable's `current` function inside notifySubscribers flow, as it means the user is reading an observable inside a store subscription. Instead the observable should be read in observing flow.