### PR TITLE
Don't clear subscribers on dispatch

### DIFF
--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -165,12 +165,8 @@ export const createThrottledStore = (
         pendingObservableNotifications.add(observable)
     }
 
-    const resetPendingBroadcastNotifications = () => {
-        pendingBroadcastNotification = false
-    }
-
     const resetAllPendingNotifications = () => {
-        resetPendingBroadcastNotifications()
+        pendingBroadcastNotification = false
         pendingObservableNotifications = undefined
     }
 
@@ -230,7 +226,6 @@ export const createThrottledStore = (
     }
 
     const dispatch: Dispatch<AnyAction> = action => {
-        resetPendingBroadcastNotifications()
         const dispatchResult = store.dispatch(action)
         return dispatchResult
     }


### PR DESCRIPTION
Remove the call to `resetPendingBroadcastNotifications` in `dispatch` call.

All pending notifications (of both observers and subscribers) are cleared on each `notify` call. There's no point clearing subscribers notifications on each `dispatch`.

This caused the following bug: 
Two dispatch calls were made. 
The first one changed the 'subscribers state' and turned the `pendingBroadcastNotification`. 
The second call was made right after it. First thing in the dispatch flow was turning off `pendingBroadcastNotification`, and then we found out the second dispatch changed on 'observers state' and therefore the `pendingObservableNotifications` was updated.
Right after that, we got an animation frame and `notifyAll` was called, but only `pendingObservableNotifications` was on, and so we didn't update the subscribers and missed the render cycle.

![mindBlown](https://user-images.githubusercontent.com/64351631/205922263-a93abfa9-6ceb-430c-ae7c-30ef27bf7881.gif)