### PR TITLE
Add documentation to connectWithShell

### DIFF
--- a/src/connectWithShell.tsx
+++ b/src/connectWithShell.tsx
@@ -143,6 +143,16 @@ export type ConnectedComponentFactory<State = {}, OwnProps = {}, StateProps = {}
     component: React.ComponentType<OwnPropsPure & StateProps & DispatchProps>
 ) => ComponentWithChildrenProps<OwnProps>
 
+/**
+ * Connect the component as a subscriber to any state updates
+ * @param mapStateToProps - Map the state to component props
+ * @param mapDispatchToProps - Map the state dispatch function to component functional props
+ * @param boundShell - the connecting shell
+ * @param options - Optional extra settings like -
+ *  shouldComponentUpdate - Update the component only when this function returns true
+ *  allowOutOfEntrypoint - Allow connecting the component outside of Entry Point lifecycle (use only when you really have no choice)
+ *  renderOutsideProvider - Wraps the component with host and shell contexts, to allow valid connection outside AppHost
+ */
 export function connectWithShell<State = {}, OwnProps = {}, StateProps = {}, DispatchProps = {}>(
     mapStateToProps: MapStateToProps<State, OwnProps, StateProps>,
     mapDispatchToProps: MapDispatchToProps<OwnProps, DispatchProps>,
@@ -155,9 +165,7 @@ export function connectWithShell<State = {}, OwnProps = {}, StateProps = {}, Dis
             const errorText =
                 `connectWithShell(${boundShell.name})(${componentText}): ` +
                 'attempt to create component type outside of Entry Point lifecycle. ' +
-                'To fix this, call connectWithShell() from Entry Point attach() or extend(). ' +
-                'If you really have to create this component type dynamically, ' +
-                'either pass {allowOutOfEntryPoint:true} in options, or use shell.runLateInitializer().'
+                'To fix this, call connectWithShell() from Entry Point attach() or extend(). '
             throw new Error(errorText)
         }
     }

--- a/src/connectWithShell.tsx
+++ b/src/connectWithShell.tsx
@@ -132,8 +132,17 @@ function wrapWithShellRenderer<OwnProps>(
 
 export interface ConnectWithShellOptions {
     readonly componentName?: string
+    /**
+     * Allow connecting the component outside of Entry Point lifecycle (use only when you really have no choice)
+     */
     readonly allowOutOfEntryPoint?: boolean
+    /**
+     * Update the component only when this function returns true
+     */
     shouldComponentUpdate?(shell: Shell): boolean
+    /**
+     * Wraps the component with host and shell contexts, to allow valid connection outside AppHost
+     */
     renderOutsideProvider?: boolean
 }
 
@@ -147,11 +156,8 @@ export type ConnectedComponentFactory<State = {}, OwnProps = {}, StateProps = {}
  * Connect the component as a subscriber to any state updates
  * @param mapStateToProps - Map the state to component props
  * @param mapDispatchToProps - Map the state dispatch function to component functional props
- * @param boundShell - the connecting shell
- * @param options - Optional extra settings like -
- *  shouldComponentUpdate - Update the component only when this function returns true
- *  allowOutOfEntrypoint - Allow connecting the component outside of Entry Point lifecycle (use only when you really have no choice)
- *  renderOutsideProvider - Wraps the component with host and shell contexts, to allow valid connection outside AppHost
+ * @param boundShell - The connecting shell
+ * @param options - Optional extra settings
  */
 export function connectWithShell<State = {}, OwnProps = {}, StateProps = {}, DispatchProps = {}>(
     mapStateToProps: MapStateToProps<State, OwnProps, StateProps>,


### PR DESCRIPTION
In order to prevent foul usage of `allowOutOfEntrypoint`