### PR TITLE
Fix cache flushing on store change

### DIFF
--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -587,11 +587,9 @@ miss: ${memoizedWithMissHit.miss}
                 window.cancelAnimationFrame,
                 notifySubscribersIsRunning => {
                     isStoreSubscribersNotifyInProgress = notifySubscribersIsRunning
-                }
+                },
+                () => flushMemoizedForState()
             )
-            store.subscribe(() => {
-                flushMemoizedForState()
-            })
         }
 
         return store

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -126,6 +126,7 @@ export function createAppHost(initialEntryPointsOrPackages: EntryPointOrPackage[
     let store: PrivateThrottledStore | null = null
     let canInstallReadyEntryPoints: boolean = true
     let isStoreSubscribersNotifyInProgress = false
+    let isObserversNotifyInProgress = false
 
     verifyLayersUniqueness(options.layers)
 
@@ -588,6 +589,9 @@ miss: ${memoizedWithMissHit.miss}
                 window.cancelAnimationFrame,
                 notifySubscribersIsRunning => {
                     isStoreSubscribersNotifyInProgress = notifySubscribersIsRunning
+                },
+                notifyObserversIsRunning => {
+                    isObserversNotifyInProgress = notifyObserversIsRunning
                 }
             )
             store.subscribe(() => {
@@ -598,7 +602,7 @@ miss: ${memoizedWithMissHit.miss}
             })
             store.syncSubscribe(() => {
                 shouldFlushMemoization = true
-                if (isStoreSubscribersNotifyInProgress) {
+                if (isStoreSubscribersNotifyInProgress || isObserversNotifyInProgress) {
                     shouldFlushMemoization = false
                     flushMemoizedForState()
                 }

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -596,8 +596,8 @@ miss: ${memoizedWithMissHit.miss}
             )
             store.subscribe(() => {
                 if (shouldFlushMemoization) {
-                    flushMemoizedForState()
                     shouldFlushMemoization = false
+                    flushMemoizedForState()
                 }
             })
             store.syncSubscribe(() => {

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -217,9 +217,7 @@ export const createThrottledStore = (
             isStoreSubscribersNotifyInProgress = true
             notifySubscribers()
         } finally {
-            if (!isStoreSubscribersNotifyInProgress) {
-                resetAllPendingNotifications()
-            }
+            resetAllPendingNotifications()
             isStoreSubscribersNotifyInProgress = false
         }
     }
@@ -238,10 +236,7 @@ export const createThrottledStore = (
     }
 
     const dispatch: Dispatch<AnyAction> = action => {
-        // start reducer
-        const dispatchResult = store.dispatch(action) // store.subscribe
-
-        return dispatchResult
+        return store.dispatch(action)
     }
 
     const toShellAction = <T extends Action>(shell: Shell, action: T): T => ({ ...action, __shellName: shell.name })

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -154,7 +154,8 @@ export const createThrottledStore = (
     contributedState: ExtensionSlot<StateContribution>,
     requestAnimationFrame: Window['requestAnimationFrame'],
     cancelAnimationFrame: Window['cancelAnimationFrame'],
-    updateIsSubscriptionNotifyInProgress: (isSubscriptionNotifyInProgress: boolean) => void
+    updateIsSubscriptionNotifyInProgress: (isSubscriptionNotifyInProgress: boolean) => void,
+    onSubscribe?: () => void
 ): PrivateThrottledStore => {
     let pendingBroadcastNotification = false
     let pendingObservableNotifications: Set<AnyPrivateObservableState> | undefined
@@ -224,6 +225,12 @@ export const createThrottledStore = (
     store.subscribe(() => {
         cancelRender = notifyAllOnAnimationFrame()
     })
+
+    if (onSubscribe) {
+        store.subscribe(() => {
+            onSubscribe()
+        })
+    }
 
     const flush = () => {
         cancelRender()

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -155,7 +155,8 @@ export const createThrottledStore = (
     contributedState: ExtensionSlot<StateContribution>,
     requestAnimationFrame: Window['requestAnimationFrame'],
     cancelAnimationFrame: Window['cancelAnimationFrame'],
-    updateIsSubscriptionNotifyInProgress: (isSubscriptionNotifyInProgress: boolean) => void
+    updateIsSubscriptionNotifyInProgress: (isSubscriptionNotifyInProgress: boolean) => void,
+    updateIsObserversNotifyInProgress: (isObserversNotifyInProgress: boolean) => void
 ): PrivateThrottledStore => {
     let pendingBroadcastNotification = false
     let pendingObservableNotifications: Set<AnyPrivateObservableState> | undefined
@@ -209,12 +210,14 @@ export const createThrottledStore = (
 
     const notifyAll = () => {
         try {
+            updateIsObserversNotifyInProgress(true)
             notifyObservers()
             updateIsSubscriptionNotifyInProgress(true)
             notifySubscribers()
         } finally {
             resetAllPendingNotifications()
             updateIsSubscriptionNotifyInProgress(false)
+            updateIsObserversNotifyInProgress(false)
         }
     }
 

--- a/test/appHost.spec.ts
+++ b/test/appHost.spec.ts
@@ -735,17 +735,17 @@ describe('App Host', () => {
                 host.getStore().subscribe(() => {
                     // cache was flushing, so call memoized API in order to create new cache
                     const res2 = host.getAPI(memoizedAPI).getNewObject()
-                    expect(Object.is(res1, res2)).toBe(false)
-                    expect(Object.is(res2, host.getAPI(memoizedAPI).getNewObject())).toBe(true)
+                    expect(res1).not.toBe(res2)
+                    expect(res2).toBe(host.getAPI(memoizedAPI).getNewObject())
                     // dispatch new action for sync cache flushing
                     host.getStore().dispatch({ type: 'MOCK_ACTION' })
 
                     res3 = host.getAPI(memoizedAPI).getNewObject()
-                    expect(Object.is(res2, res3)).toBe(false)
+                    expect(res2).not.toBe(res3)
                 })
 
                 host.getStore().flush()
-                expect(Object.is(res3, host.getAPI(memoizedAPI).getNewObject())).toBe(true)
+                expect(res3).toBe(host.getAPI(memoizedAPI).getNewObject())
             })
 
             it('should clear memoized functions on observable dispatch', () => {

--- a/test/appHost.spec.ts
+++ b/test/appHost.spec.ts
@@ -706,7 +706,7 @@ describe('App Host', () => {
             }
 
             const createMockShell = (host: AppHost) => {
-                let observableState: ObservableState<ObservableValueSelector> = {} as any;
+                let observableState: ObservableState<ObservableValueSelector> = {} as any
                 const mockShell = addMockShell(host, {
                     declareAPIs: () => [memoizedAPI],
                     attach(shell) {


### PR DESCRIPTION
This PR fixes the issue with cached function(with memoizeForState):
When action is dispatched from sync code (for example inside React Component `didMount` hook, or inside `store.subscribe`), memoized function doesn't clear cache and return cached(outdated) value.

With fixes, when action is dispatched from sync code, it's clear cache(before execution goes out from execution stack) which is guarantee that memoized function will return latest data.

For example:
```
// sync code start
dispatch({type: 'ACTION'})
someAPI.memMethod() // this will return latest value
// sync code end
```
