### PR TITLE
feat: better typings project references for pluggable

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.302.28",
   "license": "MIT",
   "description": "Allows composition of a React-with-Redux application entirely from a list of pluggable packages",
-  "main": "dist/src/index.js",
-  "module": "dist/es/src/index.js",
+  "exports": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
   "unpkg": true,
   "author": {
     "name": "Wix.com",
@@ -84,5 +84,8 @@
     "(src|test|testKit)/**/*.{ts,tsx}": [
       "tslint --project ."
     ]
+  },
+  "engines" : {
+    "node" : ">=12.7.0"
   }
 }


### PR DESCRIPTION
1. `main` replaced to `exports`

The ["exports"](https://nodejs.org/api/packages.html#exports) provides a modern alternative to ["main"](https://nodejs.org/api/packages.html#main) allowing multiple entry points to be defined, conditional entry resolution support between environments, and preventing any other entry points besides those defined in ["exports"](https://nodejs.org/api/packages.html#exports). This encapsulation allows module authors to clearly define the public interface for their package.

**For new packages targeting the currently supported versions of Node.js, the ["exports"](https://nodejs.org/api/packages.html#exports) field is recommended.**
See https://nodejs.org/api/packages.html#package-entry-points

2. `module` removed
The module field is not officially defined by Node.js and support is not planned. Instead, the Node.js community settled on [package exports](https://nodejs.org/api/packages.html#exports) which they believe is more versatile.

For practical reasons JavaScript bundlers will continue to support the module field. The esbuild docs [explain](https://esbuild.github.io/api/#main-fields) when to use module as well as related fields main and browser.

4. `types` added
TypeScript [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html)
- VS Code navigation goes to the *.ts source file not to the *.d.ts file.
- The package.json types value references the *.d.ts file.

Also see https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package and https://www.typescriptlang.org/docs/handbook/project-references.html