### PR TITLE
Include error.message in ErrorBoundary for better Sentry grouping

### DIFF
--- a/packages/repluggable/src/errorBoundary.tsx
+++ b/packages/repluggable/src/errorBoundary.tsx
@@ -56,10 +56,11 @@ export class ErrorBoundary extends React.Component<React.PropsWithChildren<Error
         const { enableStickyErrorBoundaries } = getHostOptions(shell)
 
         const errorType = isErrorLikeObject(error) ? error.name : 'UnknownError'
+        const errorDescription = isErrorLikeObject(error) ? `${errorType} | ${error.message}` : errorType
         const qualifiedName = getQualifiedName(shell.name, componentName)
         shell.log.error(
-            `ErrorBoundary(${qualifiedName}): ${errorType}`,
-            new Error(`ErrorBoundary(${qualifiedName}): ${errorType}`, { cause: error }),
+            `ErrorBoundary(${qualifiedName}): ${errorDescription}`,
+            new Error(`ErrorBoundary(${qualifiedName}): ${errorDescription}`, { cause: error }),
             { componentName, componentStack: errorInfo.componentStack }
         )
 


### PR DESCRIPTION
## Summary
- Include `error.message` alongside `error.name` in `ErrorBoundary.componentDidCatch` log output
- Changes format from `ErrorBoundary(shell / Comp): TypeError` to `ErrorBoundary(shell / Comp): TypeError | Cannot read property 'foo' of undefined`

## Motivation
Currently, `ErrorBoundary.componentDidCatch` logs errors using only `error.name` (e.g. `"TypeError"`, `"Error"`). Since most thrown errors share a handful of generic type names, Sentry groups many unrelated failures into one mega-issue per component. This makes it difficult to triage and prioritize individual bugs.

By appending `error.message` to the log string, each unique error produces a distinct fingerprint in Sentry. This splits the mega-issues into separate, actionable entries — making it much easier to identify, track, and resolve individual failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)