### PR TITLE
Add scoped connectWithShell logger override

### DIFF
--- a/packages/repluggable/src/connectWithShell.tsx
+++ b/packages/repluggable/src/connectWithShell.tsx
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import React from 'react'
 import { connect as reduxConnect } from 'react-redux'
 import { Action, Dispatch } from 'redux'
-import { AnyFunction, ObservableState, StateObserverUnsubscribe, PrivateShell, Shell } from './API'
+import { AnyFunction, ObservableState, StateObserverUnsubscribe, PrivateShell, Shell, ShellLogger } from './API'
 import { ErrorBoundary } from './errorBoundary'
 import { ShellContext } from './shellContext'
 import { StoreContext } from './storeContext'
@@ -36,6 +36,16 @@ const reduxConnectOptions = {
     context: StoreContext,
     areStatePropsEqual: propsDeepEqual,
     areOwnPropsEqual: propsDeepEqual
+}
+
+function createShellWithLogger(shell: Shell, logger?: ShellLogger): Shell {
+    return logger
+        ? new Proxy(shell, {
+              get(target, property, receiver) {
+                  return property === 'log' ? logger : Reflect.get(target, property, receiver)
+              }
+          })
+        : shell
 }
 
 function wrapWithShouldUpdate<Props extends unknown, F extends (next: Props, prev: Props) => void>(
@@ -80,6 +90,8 @@ function wrapWithShellContext<State, OwnProps, StateProps, DispatchProps>(
     boundShell: Shell,
     options: ConnectWithShellOptions<OwnProps, StateProps> = {}
 ): ComponentWithChildrenProps<OwnProps> {
+    const effectiveShell = createShellWithLogger(boundShell, options.logger)
+
     class ConnectedComponent
         extends React.Component<WrappedComponentOwnProps<OwnProps>>
         implements WrapperMembers<State, OwnProps, StateProps, DispatchProps>
@@ -92,26 +104,26 @@ function wrapWithShellContext<State, OwnProps, StateProps, DispatchProps>(
             super(props)
             this.mapStateToProps = mapStateToProps
                 ? (__, ownProps?) => {
-                      return this.props.shell.log.monitor(`connectWithShell.mapStateToProps (${this.getQualifiedName()})`, {}, () =>
-                          mapStateToProps(this.props.shell, this.props.shell.getStore<State>().getState(), ownProps)
+                      return effectiveShell.log.monitor(`connectWithShell.mapStateToProps (${this.getQualifiedName()})`, {}, () =>
+                          mapStateToProps(effectiveShell, effectiveShell.getStore<State>().getState(), ownProps)
                       )
                   }
                 : (_.stubObject as Returns<StateProps>)
             this.mapDispatchToProps = mapDispatchToProps
                 ? (dispatch, ownProps?) => {
-                      return this.props.shell.log.monitor(`connectWithShell.mapDispatchToProps (${this.getQualifiedName()})`, {}, () =>
-                          mapDispatchToProps(this.props.shell, dispatch, ownProps)
+                      return effectiveShell.log.monitor(`connectWithShell.mapDispatchToProps (${this.getQualifiedName()})`, {}, () =>
+                          mapDispatchToProps(effectiveShell, dispatch, ownProps)
                       )
                   }
                 : (_.stubObject as Returns<DispatchProps>)
 
             const shouldComponentUpdate =
-                options.shouldComponentUpdate && this.props.shell.memoizeForState(options.shouldComponentUpdate, () => '*')
+                options.shouldComponentUpdate && boundShell.memoizeForState(options.shouldComponentUpdate, () => '*')
 
             const memoWithShouldUpdate = <F extends AnyFunction>(f: F): F => {
                 let last: ReturnType<F> | null = null
                 return ((...args) => {
-                    if (last && shouldComponentUpdate && !shouldComponentUpdate(this.props.shell, this.getOwnProps())) {
+                    if (last && shouldComponentUpdate && !shouldComponentUpdate(effectiveShell, this.getOwnProps())) {
                         return last
                     }
                     last = f(...args)
@@ -130,13 +142,13 @@ function wrapWithShellContext<State, OwnProps, StateProps, DispatchProps>(
                               shouldComponentUpdate,
                               reduxConnectOptions.areStatePropsEqual,
                               this.getOwnProps,
-                              boundShell
+                              effectiveShell
                           ),
                           areOwnPropsEqual: arePropsEqualFuncWrapper(
                               shouldComponentUpdate,
                               reduxConnectOptions.areOwnPropsEqual,
                               this.getOwnProps,
-                              boundShell
+                              effectiveShell
                           )
                       }
                     : reduxConnectOptions
@@ -170,8 +182,8 @@ function wrapWithShellContext<State, OwnProps, StateProps, DispatchProps>(
         <ShellContext.Consumer>
             {shell => {
                 return (
-                    <ErrorBoundary shell={boundShell} componentName={resolveComponentName(component, options.componentName)}>
-                        {<ConnectedComponent {...wrapChildrenIfNeeded(props, shell)} shell={boundShell} />}
+                    <ErrorBoundary shell={effectiveShell} componentName={resolveComponentName(component, options.componentName)}>
+                        {<ConnectedComponent {...wrapChildrenIfNeeded(props, shell)} shell={effectiveShell} />}
                     </ErrorBoundary>
                 )
             }}
@@ -190,6 +202,7 @@ function wrapWithShellRenderer<OwnProps>(
 
 export interface ConnectWithShellOptions<OwnProps, StateProps> {
     readonly componentName?: string
+    readonly logger?: ShellLogger
     /**
      * Allow connecting the component outside of Entry Point lifecycle (use only when you really have no choice)
      */

--- a/packages/repluggable/test/connectWithShell.spec.tsx
+++ b/packages/repluggable/test/connectWithShell.spec.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, ReactElement, useEffect } from 'react'
 
 import { act, create, ReactTestInstance, ReactTestRenderer } from 'react-test-renderer'
 import { AnyAction } from 'redux'
-import { ObservedSelectorsMap, observeWithShell } from '../src'
+import { ErrorBoundary, ObservedSelectorsMap, observeWithShell } from '../src'
 import { AnySlotKey, AppHost, EntryPoint, ObservableState, Shell, ShellLogger, SlotKey } from '../src/API'
 import {
     collectAllTexts,
@@ -15,7 +15,6 @@ import {
     MockState,
     renderInHost,
     TOGGLE_MOCK_VALUE,
-    withConsoleErrors,
     withThrowOnError
 } from '../testKit'
 
@@ -152,22 +151,28 @@ describe('connectWithShell', () => {
     it('should use custom logger for connected error boundary errors', () => {
         const { shell, renderInShellContext } = createMocks(mockPackage)
         const logger = createShellLoggerMock()
-        const FailingComp = () => {
-            throw new Error('Test error')
-        }
+        const PureComp = () => <div>Pure Comp</div>
 
         const ConnectedComp = connectWithShell(undefined, undefined, shell, {
             allowOutOfEntryPoint: true,
-            componentName: 'FailingComp',
+            componentName: 'PureComp',
             logger
-        })(FailingComp)
+        })(PureComp)
 
-        withConsoleErrors(() => renderInShellContext(<ConnectedComp />))
+        const { testKit } = renderInShellContext(<ConnectedComp />)
+        const boundary = testKit.root
+            .findAll(x => _.get(x.type, 'name') === ErrorBoundary.name)
+            .find(x => x.props.componentName === 'PureComp')?.instance as ErrorBoundary
+        expect(boundary).toBeDefined()
+
+        act(() => {
+            boundary.componentDidCatch(new Error('Test error'), { componentStack: 'test stack' })
+        })
 
         expect(logger.error).toHaveBeenCalledWith(
             expect.stringContaining('ErrorBoundary'),
             expect.any(Error),
-            expect.objectContaining({ componentName: 'FailingComp' })
+            expect.objectContaining({ componentName: 'PureComp' })
         )
         expect(shell.log).not.toBe(logger)
     })

--- a/packages/repluggable/test/connectWithShell.spec.tsx
+++ b/packages/repluggable/test/connectWithShell.spec.tsx
@@ -4,7 +4,7 @@ import React, { FunctionComponent, ReactElement, useEffect } from 'react'
 import { act, create, ReactTestInstance, ReactTestRenderer } from 'react-test-renderer'
 import { AnyAction } from 'redux'
 import { ObservedSelectorsMap, observeWithShell } from '../src'
-import { AnySlotKey, AppHost, EntryPoint, ObservableState, Shell, SlotKey } from '../src/API'
+import { AnySlotKey, AppHost, EntryPoint, ObservableState, Shell, ShellLogger, SlotKey } from '../src/API'
 import {
     collectAllTexts,
     connectWithShell,
@@ -15,6 +15,7 @@ import {
     MockState,
     renderInHost,
     TOGGLE_MOCK_VALUE,
+    withConsoleErrors,
     withThrowOnError
 } from '../testKit'
 
@@ -52,6 +53,20 @@ const dispatchAndFlush = (action: AnyAction, { getStore }: AppHost) => {
     })
 }
 
+const createShellLoggerMock = (): ShellLogger =>
+    ({
+        log: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warning: jest.fn(),
+        error: jest.fn(),
+        critical: jest.fn(),
+        spanChild: jest.fn(() => ({ end: jest.fn() })),
+        spanRoot: jest.fn(() => ({ end: jest.fn() })),
+        monitor: jest.fn((messageId: string, keyValuePairs: Object, monitoredCode: () => unknown) => monitoredCode())
+    } as ShellLogger)
+
 describe('connectWithShell', () => {
     it('should pass exact shell to mapStateToProps', () => {
         const { shell, renderInShellContext } = createMocks(mockPackage)
@@ -65,6 +80,96 @@ describe('connectWithShell', () => {
 
         const { parentWrapper } = renderInShellContext(<ConnectedComp />)
         expect(collectAllTexts(parentWrapper)).toContain(mockPackage.name)
+    })
+
+    it('should use custom logger for map callbacks without mutating the original shell', () => {
+        const { shell, renderInShellContext } = createMocks(mockPackage)
+        const originalLogger = shell.log
+        const logger = createShellLoggerMock()
+        const receivedShells: Shell[] = []
+
+        const PureComp = ({
+            stateLoggerMatches,
+            dispatchLoggerMatches
+        }: {
+            stateLoggerMatches: boolean
+            dispatchLoggerMatches: boolean
+        }) => <div>{`${stateLoggerMatches}:${dispatchLoggerMatches}`}</div>
+        const mapStateToProps = (s: Shell) => {
+            receivedShells.push(s)
+            s.log.info('mapStateToProps')
+            return { stateLoggerMatches: s.log === logger }
+        }
+        const mapDispatchToProps = (s: Shell) => {
+            receivedShells.push(s)
+            s.log.warning('mapDispatchToProps')
+            return { dispatchLoggerMatches: s.log === logger }
+        }
+
+        const ConnectedComp = connectWithShell(mapStateToProps, mapDispatchToProps, shell, {
+            allowOutOfEntryPoint: true,
+            logger
+        })(PureComp)
+
+        const { parentWrapper } = renderInShellContext(<ConnectedComp />)
+
+        expect(collectAllTexts(parentWrapper)).toContain('true:true')
+        expect(logger.monitor).toHaveBeenCalledWith(expect.stringContaining('connectWithShell.mapStateToProps'), {}, expect.any(Function))
+        expect(logger.monitor).toHaveBeenCalledWith(
+            expect.stringContaining('connectWithShell.mapDispatchToProps'),
+            {},
+            expect.any(Function)
+        )
+        expect(logger.info).toHaveBeenCalledWith('mapStateToProps')
+        expect(logger.warning).toHaveBeenCalledWith('mapDispatchToProps')
+        expect(shell.log).toBe(originalLogger)
+        expect(receivedShells.every(s => s.log === logger)).toBe(true)
+        expect(receivedShells.every(s => s !== shell)).toBe(true)
+    })
+
+    it('should use custom logger in shouldComponentUpdate', () => {
+        const { shell, renderInShellContext } = createMocks(mockPackage)
+        const logger = createShellLoggerMock()
+        const receivedShells: Shell[] = []
+
+        const PureComp: FunctionComponent<{ ownProp: boolean }> = () => <div>Pure Comp</div>
+        const ConnectedComp = connectWithShell<{}, { ownProp: boolean }>(undefined, undefined, shell, {
+            allowOutOfEntryPoint: true,
+            logger,
+            shouldComponentUpdate: s => {
+                receivedShells.push(s)
+                return true
+            }
+        })(PureComp)
+
+        renderInShellContext(<ConnectedComp ownProp={true} />)
+
+        expect(receivedShells.length).toBeGreaterThan(0)
+        expect(receivedShells.every(s => s.log === logger)).toBe(true)
+        expect(shell.log).not.toBe(logger)
+    })
+
+    it('should use custom logger for connected error boundary errors', () => {
+        const { shell, renderInShellContext } = createMocks(mockPackage)
+        const logger = createShellLoggerMock()
+        const FailingComp = () => {
+            throw new Error('Test error')
+        }
+
+        const ConnectedComp = connectWithShell(undefined, undefined, shell, {
+            allowOutOfEntryPoint: true,
+            componentName: 'FailingComp',
+            logger
+        })(FailingComp)
+
+        withConsoleErrors(() => renderInShellContext(<ConnectedComp />))
+
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('ErrorBoundary'),
+            expect.any(Error),
+            expect.objectContaining({ componentName: 'FailingComp' })
+        )
+        expect(shell.log).not.toBe(logger)
     })
 
     it('should have shell context outside of main view with renderOutsideProvider option', () => {


### PR DESCRIPTION
## Summary
- Add a per-connection `ShellLogger` override to `connectWithShell` options.
- Route map callback monitoring, callback `shell.log`, `shouldComponentUpdate`, and connected error-boundary logging through a local shell proxy without mutating the original shell.
- Cover the scoped logger behavior with focused `connectWithShell` tests.

## Test plan
- `yarn workspace repluggable test connectWithShell.spec.tsx --runInBand --globals '{"ts-jest":{"diagnostics":false}}' --moduleNameMapper '{"^repluggable-core$":"<rootDir>/../repluggable-core/src"}' --testNamePattern 'custom logger'`


Made with [Cursor](https://cursor.com)